### PR TITLE
don't hardcode storyclass-name

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 apiVersion: v1
 
-version: "1.0.5"
-appVersion: "0.25.0"
+version: "1.0.6"
+appVersion: "0.25.1"
 
 name: rasa-x
 description: Rasa X Helm chart for Kubernetes / Openshift

--- a/charts/rasa-x/templates/_helpers.tpl
+++ b/charts/rasa-x/templates/_helpers.tpl
@@ -131,3 +131,16 @@ Return the port of the action container.
 {{- define "rasa-x.custom-actions.port" -}}
 {{- default 5055 .Values.app.port -}}
 {{- end -}}
+
+{{/*
+Return the storage class name which should be used.
+*/}}
+{{- define "rasa-x.persistence.storageClass" -}}
+{{- if .Values.rasax.persistence.storageClassName }}
+  {{- if (eq "-" .Values.rasax.persistence.storageClassName) }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: "{{ .Values.rasax.persistence.storageClassName }}"
+  {{- end -}}
+{{- end -}}
+{{- end }}

--- a/charts/rasa-x/templates/rasa-x-volumeclaim.yaml
+++ b/charts/rasa-x/templates/rasa-x-volumeclaim.yaml
@@ -22,5 +22,5 @@ spec:
   resources:
     requests:
       storage: {{ .Values.rasax.persistence.size | quote }}
-  storageClassName: {{ .Values.rasax.persistence.storageClassName }}
+  {{- include "rasa-x.persistence.storageClass" . }}
 {{- end -}}

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -31,7 +31,7 @@ rasax:
   ##
   persistence:
     # storageClassName the volume claim should use
-    storageClassName: "standard"
+    # storageClassName: "-"
     # access Modes of the pvc
     accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
Proposed Changes:
- remove hardcoded storage class
- fix https://github.com/RasaHQ/rasa-x-helm/issues/14
- only include `storageClassName` key in `pvc` when it's actually set to avoid issues with `helm upgrade`. (basically applying the solution from https://github.com/helm/charts/issues/20389#issuecomment-583854511)