### PR TITLE
Explicitly specify that `extraEnvs` is an array, not string

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 
-version: "1.1.2"
+version: "1.1.3"
 appVersion: "0.25.1"
 
 name: rasa-x

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -47,7 +47,7 @@ rasax:
   # resources which Rasa X is required / allowed to use
   resources:
   # extraEnvs are environment variables which can be added to the Rasa X deployment
-  extraEnvs:
+  extraEnvs: []
   # - name: SOME_CUSTOM_ENV_VAR
   #   value: "custom value"
 # rasa: Settings common for all Rasa containers
@@ -70,7 +70,7 @@ rasa:
   # lockStoreDatabase is the database in redis which Rasa uses to store the conversation locks
   lockStoreDatabase: "1"
   # extraEnvs are environment variables which can be added to the Rasa deployment
-  extraEnvs:
+  extraEnvs: []
     # example which sets env variables in each Rasa Open Source service from a separate k8s secret
     # - name: "TWILIO_ACCOUNT_SID"
     #   valueFrom:


### PR DESCRIPTION
When I try to modify `extraEnvs` using a bash script, I update this value using the following command:
```
--set rasax.extraEnvs[0].name="QUICK_INSTALL",rasax.extraEnvs[0].value=true
```

However, it doesn't pass the validation because it's not explicitly specified that `extraEnvs` is an array.

```
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Deployment.spec.template.spec.containers[0].env[20].value): invalid type for io.k8s.api.core.v1.EnvVar.value: got "array", expected "string"
```

This PR fixes this issue.