### PR TITLE
Rasa X 0.26.0

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 apiVersion: v1
 
-version: "1.1.5"
-appVersion: "0.25.1"
+version: "1.1.6"
+appVersion: "0.26.0"
 
 name: rasa-x
 description: Rasa X Helm chart for Kubernetes / Openshift

--- a/charts/rasa-x/templates/_postgresql.tpl
+++ b/charts/rasa-x/templates/_postgresql.tpl
@@ -22,7 +22,7 @@ Override the fullname template of the subchart.
 Return the db database name.
 */}}
 {{- define "rasa-x.psql.database" -}}
-{{- coalesce .Values.global.postgresql.postgresqlDatabase "rasa" -}}
+{{- coalesce .Values.rasax.databaseName .Values.global.postgresql.postgresqlDatabase "rasa" -}}
 {{- end -}}
 
 {{/*

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -55,7 +55,7 @@ rasa:
   # name of the Rasa image to use
   name: "rasa/rasa"
   # tag refers to the Rasa image tag
-  tag: "1.7.0"  # Please check the README to see all locations which have to be updated for a rasa release)
+  tag: "1.8.1"  # Please check the README to see all locations which have to be updated for a rasa release)
   # port on which Rasa runs
   port: 5005
   # token Rasa accepts as authentication token from other Rasa services

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -17,7 +17,8 @@ rasax:
   # jwtSecret which is used to sign the jwtTokens of the users
   jwtSecret: "jwtSecret"
   # databaseName Rasa X uses to store data
-  databaseName: "rasa"
+  # (uses the value of global.postgresql.postgresqlDatabase by default)
+  databaseName: ""
   # disableTelemetry permanently disables telemetry
   disableTelemetry: false
   # initialUser is the user which is created upon the initial start of Rasa X


### PR DESCRIPTION
- bump Rasa X version to 0.26.0
- bump Rasa version to 1.8.1
- make use of `rasax.databaseName` in case it's specified (wasn't used before)