### PR TITLE
add duckling url env var

### DIFF
--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -48,9 +48,9 @@ rasax:
   # resources which Rasa X is required / allowed to use
   resources:
   # extraEnvs are environment variables which can be added to the Rasa X deployment
-  extraEnvs: []
-  # - name: SOME_CUSTOM_ENV_VAR
-  #   value: "custom value"
+  extraEnvs:
+   - name: "RASA_DUCKLING_HTTP_URL"
+     value: "http://rasa-rasa-x-duckling:8000"
 
   # tolerations can be used to control the pod to node assignment
   # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/


### PR DESCRIPTION
A stab at fixing https://github.com/RasaHQ/rasa-x-helm/issues/36

- add duckling env var to the `extraEnvs` on the rasa service
- fix https://github.com/RasaHQ/rasa-x-helm/issues/36