### PR TITLE
switch back to offical actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,9 @@ jobs:
       run: |
         kubectl wait \
           --for=condition=available \
-          --timeout=420s \
+          --timeout=10m \
           -l "app.kubernetes.io/component=rasa-x" deployment
+        kubectl get pods
 
     - name: Validate that logging in works
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
         curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
 
-    - name: Lint chart
+    - name: Lint chart using Helm CLI
       run: |
         helm lint --strict ${CHART}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
       uses: helm/chart-testing-action@v1.0.0-rc.2
       with:
         command: lint
+        config: ct.yaml
 
   deploy_chart:
     name: Test the deployment of the chart

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,11 @@ jobs:
       run: |
         helm lint --strict ${CHART}
 
-    # TODO: Consider switching back to this once it's Helm 3 compatible
-    # - name: Run chart-testing (lint)
-    #   id: lint
-    #   uses: helm/chart-testing-action@v1.0.0-alpha.3
-    #   with:
-    #     command: lint
-    #     image: quay.io/helmpack/chart-testing:v3.0.0-beta.2
+    - name: Run chart-testing (lint)
+      id: lint
+      uses: helm/chart-testing-action@v1.0.0-rc.2
+      with:
+        command: lint
 
   deploy_chart:
     name: Test the deployment of the chart

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,10 @@ jobs:
           --for=condition=available \
           --timeout=10m \
           -l "app.kubernetes.io/component=rasa-x" deployment
-        kubectl get pods
+
+    - name: Log pod status for debugging
+      if: failure()
+      run: kubectl get pods
 
     - name: Validate that logging in works
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,6 @@ jobs:
         helm repo add bitnami https://charts.bitnami.com/bitnami
 
     - name: Run chart-releaser
-      uses: wochinge/chart-releaser-action@chart-releaser-from-git
+      uses: helm/chart-releaser-action@v1.0.0-rc.2
       env:
         CR_TOKEN: "${{ secrets.CR_TOKEN }}"
-        CHART_RELEASE_COMMIT_HASH: "89c97cd5a8e28959ffe6c272b64c695d068f3f7f"

--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "1.2.3"
+version: "1.2.4"
 appVersion: "0.26.0"
 
 name: rasa-x

--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 
 version: "1.2.4"
-appVersion: "0.26.0"
+appVersion: "0.27.4"
 
 name: rasa-x
 description: Rasa X Helm chart for Kubernetes / Openshift

--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "1.2.5"
+version: "1.2.6"
 appVersion: "0.27.4"
 
 name: rasa-x

--- a/charts/rasa-x/templates/app-deployment.yaml
+++ b/charts/rasa-x/templates/app-deployment.yaml
@@ -42,7 +42,9 @@ spec:
           httpGet:
             path: "{{ .Values.app.endpoints.healthCheckUrl }}"
             port: "http"
+        {{- with .Values.app.resources }}
         resources:
-          {{- toYaml .Values.app.resources | nindent 10 }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         env:
           {{- toYaml .Values.app.extraEnvs | nindent 10 }}

--- a/charts/rasa-x/templates/duckling-deployment.yaml
+++ b/charts/rasa-x/templates/duckling-deployment.yaml
@@ -43,6 +43,8 @@ spec:
           httpGet:
             path: "/"
             port: "http"
+        {{- with .Values.duckling.resources }}
         resources:
-          {{- toYaml .Values.duckling.resources | nindent 10 }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
 {{- end }}

--- a/charts/rasa-x/templates/event-service-deployment.yaml
+++ b/charts/rasa-x/templates/event-service-deployment.yaml
@@ -63,8 +63,10 @@ spec:
           value: "false"
         {{- include "rasa-x.psql.envs" . | nindent 8 }}
         {{- include "rasax.event-service.extra.envs" . | nindent 8 }}
+        {{- with .Values.eventService.resources }}
         resources:
-          {{- toYaml .Values.eventService.resources | nindent 10 }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - mountPath: "/app/endpoints.yml"
           subPath: "endpoints.yml"

--- a/charts/rasa-x/templates/nginx-deployment.yaml
+++ b/charts/rasa-x/templates/nginx-deployment.yaml
@@ -62,8 +62,10 @@ spec:
           readOnly: true
           mountPath: "/opt/bitnami/certs"
         {{ end }}
+        {{- with .Values.nginx.resources }}
         resources:
-          {{- toYaml .Values.nginx.resources | nindent 10 }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       volumes:
       - configMap:
           items:

--- a/charts/rasa-x/templates/rasa-deployments.yaml
+++ b/charts/rasa-x/templates/rasa-deployments.yaml
@@ -61,8 +61,10 @@ spec:
         - --cors
         - '*'
         {{ if $.Values.debugMode }}- --debug{{ end }}
+        {{- with .resources }}
         resources:
-          {{- toYaml .resources | nindent 10 }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         env:
         - name: "DB_PASSWORD"
           valueFrom:

--- a/charts/rasa-x/templates/rasa-x-deployment.yaml
+++ b/charts/rasa-x/templates/rasa-x-deployment.yaml
@@ -132,8 +132,10 @@ spec:
         - mountPath: "/app/git"
           name: "rasa-x-claim"
           subPath: "git"
+        {{- with .Values.rasax.resources }}
         resources:
-          {{- toYaml .Values.rasax.resources | nindent 10 }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       volumes:
       - name: "environments"
         configMap:

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -68,7 +68,7 @@ rasa:
   # name of the Rasa image to use
   name: "rasa/rasa"
   # tag refers to the Rasa image tag
-  tag: "1.8.1"  # Please check the README to see all locations which have to be updated for a rasa release)
+  tag: "1.9.5"  # Please check the README to see all locations which have to be updated for a rasa release)
   # port on which Rasa runs
   port: 5005
   # token Rasa accepts as authentication token from other Rasa services

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -46,7 +46,7 @@ rasax:
   # initialProbeDelay for the `readinessProbe` and the `livenessProbe`
   initialProbeDelay: 10
   # resources which Rasa X is required / allowed to use
-  resources:
+  resources: {}
   # extraEnvs are environment variables which can be added to the Rasa X deployment
   extraEnvs: []
   # - name: SOME_CUSTOM_ENV_VAR
@@ -131,7 +131,7 @@ rasa:
       # rasaEnvironment it used to indicate the origin of events published to RabbitMQ (App ID message property)
       rasaEnvironment: "production"
       # resources which rasaProduction is required / allowed to use
-      resources:
+      resources: {}
     # rasaWorker is the container which does computational heavy tasks such as training
     rasaWorker:
       # replicaCount of the Rasa worker container
@@ -145,7 +145,7 @@ rasa:
       # rasaEnvironment it used to indicate the origin of events published to RabbitMQ (App ID message property)
       rasaEnvironment: "worker"
       # resources which rasaWorker is required / allowed to use
-      resources:
+      resources: {}
 
 # event-service specific settings
 eventService:
@@ -172,7 +172,7 @@ eventService:
     # "beta.kubernetes.io/instance-type": "g3.8xlarge"
 
   # resources which the event service is required / allowed to use
-  resources:
+  resources: {}
   # extraEnvs are environment variables which can be added to the eventService deployment
   extraEnvs: []
   # - name: SOME_CUSTOM_ENV_VAR
@@ -189,9 +189,9 @@ app:
   # port on which the custom action server runs
   port: 5055
   # resources which app is required / allowed to use
-  resources:
+  resources: {}
   # extraEnvs are environment variables which can be added to the app deployment
-  extraEnvs:
+  extraEnvs: []
   #  - name: DATABASE_URL
   #    valueFrom:
   #      secretKeyRef:
@@ -235,7 +235,7 @@ nginx:
     # port is the port which the nginx service exposes for HTTP connections
     port: 8000
     # nodePort can be used with a service of type `NodePort` to expose the service on a certain port of the node (https://kubernetes.io/docs/concepts/services-networking/service/#nodeport)
-    nodePort:
+    nodePort: ""
     # externalIPs can be used to expose the service to certain IPs (https://kubernetes.io/docs/concepts/services-networking/service/#external-ips)
     externalIPs: []
   # initialProbeDelay for the `readinessProbe` and the `livenessProbe`
@@ -253,7 +253,7 @@ nginx:
     # "beta.kubernetes.io/instance-type": "g3.8xlarge"
 
   # resources which nginx is required / allowed to use
-  resources:
+  resources: {}
 
 # Duckling specific settings
 duckling:
@@ -280,7 +280,7 @@ duckling:
     # "beta.kubernetes.io/instance-type": "g3.8xlarge"
 
   # resources which duckling is required / allowed to use
-  resources:
+  resources: {}
 
 # rasaSecret object which supplies passwords, tokens, etc. See
 # https://rasa.com/docs/rasa-x/openshift-kubernetes/#providing-access-credentials-using-an-external-secret

--- a/ct.yaml
+++ b/ct.yaml
@@ -3,3 +3,5 @@ remote: origin
 chart-dirs:
   - charts
 helm-extra-args: --timeout 600
+chart-repos:
+  - bitnami=https://charts.bitnami.com/bitnami


### PR DESCRIPTION
Changes:
- Both, chart-releaser and `chart-testing-action` published updates for Helm v3. Hence, we can switch back to use the officially maintained actions. 