### PR TITLE
optional login database and eventService extraEnvs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,9 @@ jobs:
       run: |
         kubectl wait \
           --for=condition=available \
-          --timeout=420s \
+          --timeout=10m \
           -l "app.kubernetes.io/component=rasa-x" deployment
+        kubectl get pods
 
     - name: Validate that logging in works
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,16 @@ jobs:
         USER_PASSWORD=$(openssl rand -base64 32)
         echo "::set-env name=INITIAL_USER_PASSWORD::${USER_PASSWORD}"
 
+    - name: Free disk space
+      # tries to make sure we do not run out of disk space, see
+      # https://github.community/t5/GitHub-Actions/BUG-Strange-quot-No-space-left-on-device-quot-IOExceptions-on/td-p/46101
+      run: |
+        sudo swapoff -a
+        sudo rm -f /swapfile
+        sudo apt clean
+        docker rmi $(docker image ls -aq)
+        df -h
+
     - name: Deploy chart
       run: |
         helm dependency update ${CHART}
@@ -81,7 +91,9 @@ jobs:
 
     - name: Log pod status for debugging
       if: failure()
-      run: kubectl get pods
+      run: |
+        kubectl get pods
+        df -h
 
     - name: Validate that logging in works
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,10 @@ jobs:
           --for=condition=available \
           --timeout=10m \
           -l "app.kubernetes.io/component=rasa-x" deployment
-        kubectl get pods
+
+    - name: Log pod status for debugging
+      if: failure()
+      run: kubectl get pods
 
     - name: Validate that logging in works
       run: |

--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 apiVersion: v2
 
-version: "1.2.3"
-appVersion: "0.26.0"
+version: "1.2.4"
+appVersion: "0.27.4"
 
 name: rasa-x
 description: Rasa X Helm chart for Kubernetes / Openshift

--- a/charts/rasa-x/templates/_helpers.tpl
+++ b/charts/rasa-x/templates/_helpers.tpl
@@ -158,6 +158,15 @@ Include rasax extra env vars.
 {{- end -}}
 
 {{/*
+Include extra env vars for the EventService.
+*/}}
+{{- define "rasax.event-service.extra.envs" -}}
+  {{- if .Values.eventService.extraEnvs -}}
+{{ toYaml .Values.eventService.extraEnvs }}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Return the storage class name which should be used.
 */}}
 {{- define "rasa-x.persistence.storageClass" -}}

--- a/charts/rasa-x/templates/event-service-deployment.yaml
+++ b/charts/rasa-x/templates/event-service-deployment.yaml
@@ -62,6 +62,7 @@ spec:
         - name: "LOCAL_MODE"
           value: "false"
         {{- include "rasa-x.psql.envs" . | nindent 8 }}
+        {{- include "rasax.event-service.extra.envs" . | nindent 8 }}
         resources:
           {{- toYaml .Values.eventService.resources | nindent 10 }}
         volumeMounts:

--- a/charts/rasa-x/templates/rasa-config-files-configmap.yaml
+++ b/charts/rasa-x/templates/rasa-config-files-configmap.yaml
@@ -24,7 +24,9 @@ data:
       username: {{ template "rasa-x.psql.username" . }}
       password: ${DB_PASSWORD}
       db: ${DB_DATABASE}
+      {{- if .Values.rasa.useLoginDatabase }}
       login_db: {{ template "rasa-x.psql.database" . }}
+      {{- end }}
     event_broker:
       type: "pika"
       url: "{{ template "rasa-x.rabbitmq.host" . }}"

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -88,7 +88,7 @@ rasa:
   # useLoginDatabase will use the Rasa X database to log in and create the database
   # for the tracker store. If `false` the tracker store database must have been created
   # previously.
-  useLoginDatabase: false
+  useLoginDatabase: true
   # lockStoreDatabase is the database in redis which Rasa uses to store the conversation locks
   lockStoreDatabase: "1"
   # extraEnvs are environment variables which can be added to the Rasa deployment

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -68,7 +68,7 @@ rasa:
   # name of the Rasa image to use
   name: "rasa/rasa"
   # tag refers to the Rasa image tag
-  tag: "1.8.1"  # Please check the README to see all locations which have to be updated for a rasa release)
+  tag: "1.9.5"  # Please check the README to see all locations which have to be updated for a rasa release)
   # port on which Rasa runs
   port: 5005
   # token Rasa accepts as authentication token from other Rasa services

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -85,6 +85,10 @@ rasa:
     #   page-access-token: "EAAbHPa7H9rEBAAuFk4Q3gPKbDedQnx4djJJ1JmQ7CAqO4iJKrQcNT0wtD"
   # initialProbeDelay for the `readinessProbe` and the `livenessProbe`
   initialProbeDelay: 10
+  # useLoginDatabase will use the Rasa X database to log in and create the database
+  # for the tracker store. If `false` the tracker store database must have been created
+  # previously.
+  useLoginDatabase: false
   # lockStoreDatabase is the database in redis which Rasa uses to store the conversation locks
   lockStoreDatabase: "1"
   # extraEnvs are environment variables which can be added to the Rasa deployment

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -186,7 +186,7 @@ app:
   port: 5055
   # resources which app is required / allowed to use
   resources:
-  # extraEnvs is a dict containing app specific env variables
+  # extraEnvs are environment variables which can be added to the app deployment
   extraEnvs:
   #  - name: DATABASE_URL
   #    valueFrom:

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -173,6 +173,10 @@ eventService:
 
   # resources which the event service is required / allowed to use
   resources:
+  # extraEnvs are environment variables which can be added to the eventService deployment
+  extraEnvs: []
+  # - name: SOME_CUSTOM_ENV_VAR
+  #   value: "custom value"
 
 # app (custom action server) specific settings
 app:


### PR DESCRIPTION
- make the login database for Rasa optional (`rasa.useLoginDatabase` value)
- make it possible to add additional environment variables for the event service deployments (`eventService.extraEnvs` variable)