### PR TITLE
remove LOCAL_MODE env variable

### DIFF
--- a/charts/rasa-x/templates/event-service-deployment.yaml
+++ b/charts/rasa-x/templates/event-service-deployment.yaml
@@ -59,7 +59,7 @@ spec:
               key: {{ template "rasa-x.rabbitmq.password.key" . }}
         - name: "RASA_X_USER_ANALYTICS"
           value: "0"
-        - name: "LOCAL_MODE"  # This variable doesn't do anything anymore in Rasa X 0.28 and later
+        - name: "LOCAL_MODE" # This variable doesn't do anything anymore in Rasa X 0.28 and later
           value: "false"
         {{- include "rasa-x.psql.envs" . | nindent 8 }}
         {{- include "rasax.event-service.extra.envs" . | nindent 8 }}

--- a/charts/rasa-x/templates/event-service-deployment.yaml
+++ b/charts/rasa-x/templates/event-service-deployment.yaml
@@ -59,6 +59,8 @@ spec:
               key: {{ template "rasa-x.rabbitmq.password.key" . }}
         - name: "RASA_X_USER_ANALYTICS"
           value: "0"
+        - name: "LOCAL_MODE"  # This variable doesn't do anything anymore in Rasa X 0.28 and later
+          value: "false"
         {{- include "rasa-x.psql.envs" . | nindent 8 }}
         {{- include "rasax.event-service.extra.envs" . | nindent 8 }}
         resources:

--- a/charts/rasa-x/templates/event-service-deployment.yaml
+++ b/charts/rasa-x/templates/event-service-deployment.yaml
@@ -59,8 +59,6 @@ spec:
               key: {{ template "rasa-x.rabbitmq.password.key" . }}
         - name: "RASA_X_USER_ANALYTICS"
           value: "0"
-        - name: "LOCAL_MODE"
-          value: "false"
         {{- include "rasa-x.psql.envs" . | nindent 8 }}
         {{- include "rasax.event-service.extra.envs" . | nindent 8 }}
         resources:

--- a/charts/rasa-x/templates/rasa-x-deployment.yaml
+++ b/charts/rasa-x/templates/rasa-x-deployment.yaml
@@ -62,7 +62,7 @@ spec:
         - name: "METRICS_CONSENT"
           value: "false"
         {{- end }}
-        - name: "LOCAL_MODE"  # This variable doesn't do anything anymore in Rasa X 0.28 and later
+        - name: "LOCAL_MODE" # This variable doesn't do anything anymore in Rasa X 0.28 and later
           value: "false"
         - name: "RASA_X_HOST"
           value: "http://{{ include "rasa-x.host" . }}:{{ .Values.rasax.port }}"

--- a/charts/rasa-x/templates/rasa-x-deployment.yaml
+++ b/charts/rasa-x/templates/rasa-x-deployment.yaml
@@ -62,6 +62,8 @@ spec:
         - name: "METRICS_CONSENT"
           value: "false"
         {{- end }}
+        - name: "LOCAL_MODE"  # This variable doesn't do anything anymore in Rasa X 0.28 and later
+          value: "false"
         - name: "RASA_X_HOST"
           value: "http://{{ include "rasa-x.host" . }}:{{ .Values.rasax.port }}"
         - name: "RASA_MODEL_DIR"

--- a/charts/rasa-x/templates/rasa-x-deployment.yaml
+++ b/charts/rasa-x/templates/rasa-x-deployment.yaml
@@ -62,8 +62,6 @@ spec:
         - name: "METRICS_CONSENT"
           value: "false"
         {{- end }}
-        - name: "LOCAL_MODE"
-          value: "false"
         - name: "RASA_X_HOST"
           value: "http://{{ include "rasa-x.host" . }}:{{ .Values.rasax.port }}"
         - name: "RASA_MODEL_DIR"


### PR DESCRIPTION
[This PR](https://github.com/RasaHQ/rasa-x/pull/2494) removes the environment variable `LOCAL_MODE` in Rasa X. The variable should therefore not be set in the helm charts anymore.