### PR TITLE
update readme and default Rasa versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ recommend to set at least these values:
 | rabbitmq.rabbitmq.password           | Password for RabbitMq.                                                                     | `test`             |
 | global.postgresql.postgresqlPassword | Password for the Postgresql database.                                                      | `password`         |
 | global.redis.password                | Password for redis.                                                                        | `password`         |
-| Chart.appVersion                     | Version of Rasa X which you want to use.                                                   | `0.25.0`           |
-| rasa.tag                             | Version of Rasa OSS which you want to use.                                                 | `1.7.0`            |
+| rasax.tag                            | Version of Rasa X which you want to use.                                                   | `0.28.3`           |
+| rasa.tag                             | Version of Rasa OSS which you want to use.                                                 | `1.10.1`           |
 | app.name                             | Name of your action server image.                                                          | `rasa/rasa-x-demo` |
-| app.tag                              | Tag of your action server image.                                                           | `0.25.0`           |
+| app.tag                              | Tag of your action server image.                                                           |  `0.28.3`          |
 
 ## Where to get help
 

--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 apiVersion: v2
 
-version: "1.2.7"
-appVersion: "0.27.4"
+version: "1.2.8"
+appVersion: "0.28.3"
 
 name: rasa-x
 description: Rasa X Helm chart for Kubernetes / Openshift

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -68,7 +68,7 @@ rasa:
   # name of the Rasa image to use
   name: "rasa/rasa"
   # tag refers to the Rasa image tag
-  tag: "1.9.5"  # Please check the README to see all locations which have to be updated for a rasa release)
+  tag: "1.10.1"  # Please check the README to see all locations which have to be updated for a rasa release)
   # port on which Rasa runs
   port: 5005
   # token Rasa accepts as authentication token from other Rasa services


### PR DESCRIPTION
**Proposed Changes**:
* update readme with new versions and remove instructions to use `Chart.appVersion` to increment Rasa X version
* update default versions for Rasa Open Source and Rasa X