### PR TITLE
bump image versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ recommend to set at least these values:
 | rabbitmq.rabbitmq.password           | Password for RabbitMq.                                                                     | `test`             |
 | global.postgresql.postgresqlPassword | Password for the Postgresql database.                                                      | `password`         |
 | global.redis.password                | Password for redis.                                                                        | `password`         |
-| rasax.tag                            | Version of Rasa X which you want to use.                                                   | `0.28.3`           |
-| rasa.tag                             | Version of Rasa OSS which you want to use.                                                 | `1.10.1`           |
+| rasax.tag                            | Version of Rasa X which you want to use.                                                   | `0.29.1`           |
+| rasa.tag                             | Version of Rasa OSS which you want to use.                                                 | `1.10.3`           |
 | app.name                             | Name of your action server image.                                                          | `rasa/rasa-x-demo` |
-| app.tag                              | Tag of your action server image.                                                           |  `0.28.3`          |
+| app.tag                              | Tag of your action server image.                                                           |  `0.29.1`          |
 
 ## Where to get help
 

--- a/README.md
+++ b/README.md
@@ -23,13 +23,14 @@ helm install <your release name> rasa-x/rasa-x
 ```
 
 ## Upgrading the deployment
-```
+
+```bash
 helm upgrade <your release name> rasa-x/rasa-x
 ```
 
 ## Uninstalling
 
-```
+```bash
 helm delete <your release name>
 ```
 
@@ -56,8 +57,8 @@ recommend to set at least these values:
 
 ## Where to get help
 
-- If you encounter bugs or have suggestions for this Helm chart, please create an issue in this repository.
-- If you have general questions about usage, please create a thread in the [Rasa Forum](https://forum.rasa.com/).
+* If you encounter bugs or have suggestions for this Helm chart, please create an issue in this repository.
+* If you have general questions about usage, please create a thread in the [Rasa Forum](https://forum.rasa.com/).
 
 ## How to contribute
 
@@ -70,8 +71,8 @@ To contribute via pull request, follow these steps:
 1. Create an issue describing the feature you want to work on
 2. Create a pull request describing your changes
 
-
 ## Development Internals
+
 ### Releasing a new version of this chart
 
 This repository automatically release a new version of the Helm chart once new changes
@@ -81,5 +82,6 @@ are merged. The only required steps are:
 2. Increase the chart `version` in `charts/rasa-x/Chart.yaml`
 
 ## License
+
 Licensed under the Apache License, Version 2.0.
 Copyright 2020 Rasa Technologies GmbH. [Copy of the license](LICENSE.txt).

--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 apiVersion: v2
 
-version: "1.2.8"
-appVersion: "0.28.3"
+version: "1.2.9"
+appVersion: "0.29.1"
 
 name: rasa-x
 description: Rasa X Helm chart for Kubernetes / Openshift

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -68,7 +68,7 @@ rasa:
   # name of the Rasa image to use
   name: "rasa/rasa"
   # tag refers to the Rasa image tag
-  tag: "1.10.1"  # Please check the README to see all locations which have to be updated for a rasa release)
+  tag: "1.10.3"  # Please check the README to see all locations which have to be updated for a rasa release)
   # port on which Rasa runs
   port: 5005
   # token Rasa accepts as authentication token from other Rasa services
@@ -262,7 +262,7 @@ duckling:
   # name of the Duckling image to use
   name: "rasa/duckling"
   # tag refers to the duckling image tag
-  tag: "0.1.6.2"
+  tag: "0.1.6.3"
   # replicaCount of duckling containers to run
   replicaCount: 1
   # port on which duckling should run


### PR DESCRIPTION
- latest patch for Rasa Open Source 
- update to new Rasa X minor (0.29)
- use Duckling 1.6.3 which has a much smaller Docker image size