### PR TITLE
Add nginx.enabled flag

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "1.3.1"
+version: "1.4.0"
 appVersion: "0.30.1"
 
 name: rasa-x

--- a/charts/rasa-x/templates/app-service.yaml
+++ b/charts/rasa-x/templates/app-service.yaml
@@ -11,11 +11,13 @@ spec:
     targetPort: {{ template "rasa-x.custom-actions.port" . }}
     protocol: "TCP"
     name: "http"
+  {{- if .Values.nginx.enabled }}
     # workaround for nginx which curls on port 80 to check availability
   - port: 80
     targetPort: 80
     protocol: "TCP"
     name: "workaround"
+  {{- end }}
   selector:
     {{- include "rasa-x.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: app

--- a/charts/rasa-x/templates/ingress.yaml
+++ b/charts/rasa-x/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled -}}
+{{- if and .Values.ingress.enabled .Values.nginx.enabled -}}
 {{- $fullName := include "rasa-x.fullname" . -}}
 {{- $svcPort := .Values.nginx.service.port -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}

--- a/charts/rasa-x/templates/nginx-configmap.yaml
+++ b/charts/rasa-x/templates/nginx-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.nginx.enabled }}
 apiVersion: "v1"
 data:
   agree: "openshift"
@@ -6,3 +7,4 @@ metadata:
   name: {{ template "rasa-x.nginx.agreement" . }}
   labels:
     {{ include "rasa-x.labels" . | nindent 4 }}
+{{- end }}

--- a/charts/rasa-x/templates/nginx-deployment.yaml
+++ b/charts/rasa-x/templates/nginx-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.nginx.enabled }}
 apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
@@ -87,3 +88,4 @@ spec:
         secret:
           secretName: {{ .Values.nginx.certificateSecret }}
       {{ end }}
+{{- end }}

--- a/charts/rasa-x/templates/nginx-service.yaml
+++ b/charts/rasa-x/templates/nginx-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.nginx.enabled }}
 apiVersion: "v1"
 kind: "Service"
 metadata:
@@ -25,3 +26,4 @@ spec:
   selector:
     {{- include "rasa-x.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: nginx
+{{- end }}

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -236,6 +236,9 @@ app:
 
 # nginx specific settings
 nginx:
+  # enabled should be `true` if you want to use nginx
+  # if you set false, you will need to set up some other method of routing (VirtualService/Ingress controller)
+  enabled: true
   # override the default command to run in the container
   command: []
   # override the default arguments to run in the container

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -399,6 +399,7 @@ redis:
 # ingress settings
 ingress:
   # enabled should be `true` if you want to use this ingress
+  # note that nginx.enabled must also be true for ingress to work
   enabled: true
   # annotations for the ingress
   annotations: {}


### PR DESCRIPTION
# Summary

Relates to #32 

- Add `.Values.nginx.enabled` which defaults to true
- Can be disabled if using your own ingress solution
  - This could be a set of Ingress objects as per the issue
  - Could be a service mesh object such as an istio `VirtualService`
- Also removes a workaround port in the custom-actions app as the comment suggests it is only for nginx healthchecks
