### PR TITLE
Set SELF_PORT on rasax for custom ports

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "1.3.1"
+version: "1.4.1"
 appVersion: "0.30.1"
 
 name: rasa-x

--- a/charts/rasa-x/templates/rasa-x-deployment.yaml
+++ b/charts/rasa-x/templates/rasa-x-deployment.yaml
@@ -71,6 +71,8 @@ spec:
         - name: "METRICS_CONSENT"
           value: "false"
         {{- end }}
+        - name: "SELF_PORT"
+          value: {{ .Values.rasax.port | quote }}
         - name: "LOCAL_MODE" # This variable doesn't do anything anymore in Rasa X 0.28 and later
           value: "false"
         - name: "RASA_X_HOST"

--- a/charts/rasa-x/templates/rasa-x-service.yaml
+++ b/charts/rasa-x/templates/rasa-x-service.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   ports:
   - port: {{ .Values.rasax.port }}
-    targetPort: 5002
+    targetPort: http
     protocol: "TCP"
     name: "http"
   selector:


### PR DESCRIPTION
# Summary

Fixes #61 

- Sets `SELF_PORT` environment variable in rasax
- This shouldn't hurt for the default values as it keep 5002
- The rasax service now points at the targetPort by name
- I have bumped the chart version to `1.4.1` assuming that #60 will be merged first (I can change that if needed)
