### PR TITLE
Make sure to redirect requests only for the /api/chat endpoint

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "1.6.3"
+version: "1.6.4"
 appVersion: "0.30.1"
 
 name: rasa-x

--- a/charts/rasa-x/templates/rasa-x-ingress.yaml
+++ b/charts/rasa-x/templates/rasa-x-ingress.yaml
@@ -17,10 +17,10 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       if ($arg_environment = "") {
-          rewrite ^/api/chat /core/webhooks/rasa/webhook last;
+          rewrite ^/api/chat$ /core/webhooks/rasa/webhook last;
       }
       if ($arg_environment = "production") {
-          rewrite ^/api/chat /core/webhooks/rasa/webhook last;
+          rewrite ^/api/chat$ /core/webhooks/rasa/webhook last;
       }
   {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
Rewrite definition for the `/api/chat` endpoint should include end of the line sign (`$`) to make sure that we rewrite requests only for the `/api/chat` endpoint.