### PR TITLE
don't mount service credentials by default

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "1.6.5"
+version: "1.6.6"
 appVersion: "0.30.1"
 
 name: rasa-x

--- a/charts/rasa-x/templates/app-deployment.yaml
+++ b/charts/rasa-x/templates/app-deployment.yaml
@@ -18,6 +18,7 @@ spec:
         {{- include "rasa-x.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: app
     spec:
+      automountServiceAccountToken: {{ .Values.app.automountServiceAccountToken }}
       {{ include "rasa-x.spec" . }}
       {{- if .Values.app.nodeSelector }}
       nodeSelector:

--- a/charts/rasa-x/templates/duckling-deployment.yaml
+++ b/charts/rasa-x/templates/duckling-deployment.yaml
@@ -19,6 +19,7 @@ spec:
         {{- include "rasa-x.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: duckling
     spec:
+      automountServiceAccountToken: false
       {{ include "rasa-x.spec" . }}
       {{- if .Values.duckling.nodeSelector }}
       nodeSelector:

--- a/charts/rasa-x/templates/event-service-deployment.yaml
+++ b/charts/rasa-x/templates/event-service-deployment.yaml
@@ -19,6 +19,7 @@ spec:
         {{- include "rasa-x.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: event-service
     spec:
+      automountServiceAccountToken: false
       {{ include "rasa-x.spec" . }}
       {{- if .Values.eventService.nodeSelector }}
       nodeSelector:

--- a/charts/rasa-x/templates/nginx-deployment.yaml
+++ b/charts/rasa-x/templates/nginx-deployment.yaml
@@ -19,6 +19,7 @@ spec:
         {{- include "rasa-x.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: nginx
     spec:
+      automountServiceAccountToken: false
       {{ include "rasa-x.spec" . }}
       {{- if .Values.nginx.nodeSelector }}
       nodeSelector:

--- a/charts/rasa-x/templates/rasa-deployments.yaml
+++ b/charts/rasa-x/templates/rasa-deployments.yaml
@@ -22,6 +22,7 @@ spec:
         checksum/rasa:
           {{- include "rasa.checksum" $ | nindent 10 }}
     spec:
+      automountServiceAccountToken: false
       {{ include "rasa-x.spec" $ }}
       {{- if $.Values.rasa.nodeSelector }}
       nodeSelector:

--- a/charts/rasa-x/templates/rasa-x-deployment.yaml
+++ b/charts/rasa-x/templates/rasa-x-deployment.yaml
@@ -25,6 +25,7 @@ spec:
         checksum/rasax:
           {{- include "rasa-x.checksum" . | nindent 10 }}
     spec:
+      automountServiceAccountToken: false
       {{ include "rasa-x.spec" . }}
       {{- if .Values.rasax.nodeSelector }}
       nodeSelector:

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -282,7 +282,7 @@ app:
   # - name: tmpdir
   #   emptyDir: {}
 
-  # automountServiceAccountToken specifies whether the Kubernetes service account 
+  # automountServiceAccountToken specifies whether the Kubernetes service account
   # credentials should be automatically mounted into the pods. See more about it in
   # https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server
   automountServiceAccountToken: true

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -282,6 +282,11 @@ app:
   # - name: tmpdir
   #   emptyDir: {}
 
+  # automountServiceAccountToken specifies whether the Kubernetes service account 
+  # credentials should be automatically mounted into the pods. See more about it in
+  # https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server
+  automountServiceAccountToken: true
+
 # nginx specific settings
 nginx:
   # enabled should be `true` if you want to use nginx


### PR DESCRIPTION
**Proposed Changes**:
- fix https://github.com/RasaHQ/rasa-x-helm/issues/76
- disable mounting service credentials for all Rasa pods by default
- mounting the service credentials is optional for the `app` container in case users want to do some crazy stuff with Kubernetes