### PR TITLE
Deprecating queue in favor of queues

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "1.6.6"
+version: "1.6.7"
 appVersion: "0.30.1"
 
 name: rasa-x

--- a/charts/rasa-x/templates/rasa-config-files-configmap.yaml
+++ b/charts/rasa-x/templates/rasa-config-files-configmap.yaml
@@ -33,7 +33,7 @@ data:
       username: "{{ .Values.rabbitmq.rabbitmq.username }}"
       password: ${RABBITMQ_PASSWORD}
       port: {{ default 5672 .Values.rabbitmq.service.port }}
-      queue: ${RABBITMQ_QUEUE}
+      queues: ${RABBITMQ_QUEUE}
     action_endpoint:
       url: "http://{{ include "rasa-x.fullname" . }}-app:{{ template "rasa-x.custom-actions.port" . }}{{ .Values.app.endpoints.actionEndpointUrl }}"
       token:  ""

--- a/charts/rasa-x/templates/rasa-config-files-configmap.yaml
+++ b/charts/rasa-x/templates/rasa-config-files-configmap.yaml
@@ -33,12 +33,12 @@ data:
       username: "{{ .Values.rabbitmq.rabbitmq.username }}"
       password: ${RABBITMQ_PASSWORD}
       port: {{ default 5672 .Values.rabbitmq.service.port }}
-      {{- if semverCompare ">= 1.9.0" .Values.rasa.tag -}}
-            queues:
-            - ${RABBITMQ_QUEUE}
+      {{ if semverCompare ">= 1.9.0" .Values.rasa.tag -}}
+      queues:
+        - ${RABBITMQ_QUEUE}
       {{- else -}}
-            queue: ${RABBITMQ_QUEUE}
-      {{- end -}}
+      queue: ${RABBITMQ_QUEUE}
+      {{- end }}
     action_endpoint:
       url: "http://{{ include "rasa-x.fullname" . }}-app:{{ template "rasa-x.custom-actions.port" . }}{{ .Values.app.endpoints.actionEndpointUrl }}"
       token:  ""

--- a/charts/rasa-x/templates/rasa-config-files-configmap.yaml
+++ b/charts/rasa-x/templates/rasa-config-files-configmap.yaml
@@ -33,7 +33,12 @@ data:
       username: "{{ .Values.rabbitmq.rabbitmq.username }}"
       password: ${RABBITMQ_PASSWORD}
       port: {{ default 5672 .Values.rabbitmq.service.port }}
-      queues: ${RABBITMQ_QUEUE}
+      {{- if semverCompare ">= 1.9.0" .Values.rasa.tag -}}
+            queues:
+            - ${RABBITMQ_QUEUE}
+      {{- else -}}
+            queue: ${RABBITMQ_QUEUE}
+      {{- end -}}
     action_endpoint:
       url: "http://{{ include "rasa-x.fullname" . }}-app:{{ template "rasa-x.custom-actions.port" . }}{{ .Values.app.endpoints.actionEndpointUrl }}"
       token:  ""


### PR DESCRIPTION
`queue` has been deprecated in favor of `queues`, so our deployment files need updating 😊 