### PR TITLE
Use checksum of templates instead of values

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "1.6.9"
+version: "1.6.10"
 appVersion: "0.30.1"
 
 name: rasa-x

--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "1.6.7"
+version: "1.6.8"
 appVersion: "0.30.1"
 
 name: rasa-x

--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "1.6.8"
+version: "1.6.9"
 appVersion: "0.30.1"
 
 name: rasa-x

--- a/charts/rasa-x/templates/_helpers.tpl
+++ b/charts/rasa-x/templates/_helpers.tpl
@@ -180,13 +180,6 @@ Return the storage class name which should be used.
 {{- end }}
 
 {{/*
-Return the checksum of Rasa values.
-*/}}
-{{- define "rasa.checksum" -}}
-{{ toYaml .Values.rasa | sha256sum }}
-{{- end -}}
-
-{{/*
 Return the checksum of Rasa X values.
 */}}
 {{- define "rasa-x.checksum" -}}

--- a/charts/rasa-x/templates/rasa-deployments.yaml
+++ b/charts/rasa-x/templates/rasa-deployments.yaml
@@ -19,8 +19,8 @@ spec:
         {{- include "rasa-x.selectorLabels" $ | nindent 8 }}
         app.kubernetes.io/component: {{ .serviceName }}
       annotations:
-        checksum/rasa:
-          {{- include "rasa.checksum" $ | nindent 10 }}
+        checksum/rasa-config: {{ include (print $.Template.BasePath "/rasa-config-files-configmap.yaml") $ | sha256sum }}
+        checksum/rasa-secret: {{ include (print $.Template.BasePath "/rasa-secret.yaml") $ | sha256sum }}
     spec:
       automountServiceAccountToken: false
       {{ include "rasa-x.spec" $ }}

--- a/charts/rasa-x/templates/rasa-deployments.yaml
+++ b/charts/rasa-x/templates/rasa-deployments.yaml
@@ -101,13 +101,6 @@ spec:
             secretKeyRef:
               name: {{ template "rasa-x.secret" $ }}
               key: "rasaToken"
-        - name: "RASA_X_USERNAME"
-          value: "{{ $.Values.rasax.initialUser.username }}"
-        - name: "RASA_X_PASSWORD"
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "rasa-x.secret" $ }}
-              key: "initialPassword"
         - name: "RABBITMQ_QUEUE"
           value: "{{ $.Values.rasa.rabbitQueue }}"
         - name: "JWT_SECRET"

--- a/charts/rasa-x/templates/rasa-x-deployment.yaml
+++ b/charts/rasa-x/templates/rasa-x-deployment.yaml
@@ -20,10 +20,9 @@ spec:
         {{- include "rasa-x.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: rasa-x
       annotations:
-        checksum/rasa:
-          {{- include "rasa.checksum" . | nindent 10 }}
-        checksum/rasax:
-          {{- include "rasa-x.checksum" . | nindent 10 }}
+        checksum/rasa-config: {{ include (print $.Template.BasePath "/rasa-config-files-configmap.yaml") . | sha256sum }}
+        checksum/rasa-x-config: {{ include (print $.Template.BasePath "/rasa-x-config-files-configmap.yaml") . | sha256sum }}
+        checksum/rasa-secret: {{ include (print $.Template.BasePath "/rasa-secret.yaml") . | sha256sum }}
     spec:
       automountServiceAccountToken: false
       {{ include "rasa-x.spec" . }}


### PR DESCRIPTION
In some cases, changes in values are not relevant for the rasa-x deployment, but because we count checksum for the rasa and rasa-x values it triggers an upgrade even if it is not needed.  

Instead of counting checksum for the values, we should count checksum of templates for secrets and configmaps.

Fixes #69  

