### PR TITLE
allow commit sha as tag for rasa

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 
 
-version: "1.6.10"
+version: "1.6.11"
 appVersion: "0.30.1"
 
 name: rasa-x

--- a/charts/rasa-x/templates/rasa-config-files-configmap.yaml
+++ b/charts/rasa-x/templates/rasa-config-files-configmap.yaml
@@ -33,7 +33,7 @@ data:
       username: "{{ .Values.rabbitmq.rabbitmq.username }}"
       password: ${RABBITMQ_PASSWORD}
       port: {{ default 5672 .Values.rabbitmq.service.port }}
-      {{ if or (regexMatch ".*(a|rc)[0-9]+" .Values.rasa.tag) (regexMatch "2.*[0-9]+-full" .Values.rasa.tag) -}}
+      {{ if or (regexMatch ".*(a|rc)[0-9]+" .Values.rasa.tag) (regexMatch "2.*[0-9]+-full" .Values.rasa.tag) (regexMatch "([a-z][0-9])+" .Values.rasa.tag) -}}
       queues:
       - ${RABBITMQ_QUEUE}
       {{- else -}}


### PR DESCRIPTION
This PR allows the use of commit sha sums as image tags for the rasa image.

/closes #86 