### PR TITLE
Jaeger sidecar & addl endpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
 
     - name: Lint chart using Helm CLI
       run: |
+        helm dependency update ${CHART}
         helm lint --strict ${CHART}
 
     - name: Run chart-testing (lint)

--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,5 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.gitignore.io/api/helm,linux,macos,pycharm,windows,visualstudiocode
+# Local values examples
+.values/

--- a/.gitignore
+++ b/.gitignore
@@ -174,4 +174,5 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
-
+# End of https://www.gitignore.io/api/helm,linux,macos,pycharm,windows,visualstudiocode
+./values

--- a/.gitignore
+++ b/.gitignore
@@ -175,6 +175,3 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
-# End of https://www.gitignore.io/api/helm,linux,macos,pycharm,windows,visualstudiocode
-# Local values examples
-.values/

--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ This repository automatically release a new version of the Helm chart once new c
 are merged. The only required steps are:
 
 1. Make the changes to the chart
-2. Increase the chart `version` in `charts/rasa-x/Chart.yaml`
+2. Run `helm lint --strict charts/rasa-x`
+3. Increase the chart `version` in `charts/rasa-x/Chart.yaml`
 
 ## License
 

--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 
 
-version: "1.6.10"
+version: "1.6.11"
 appVersion: "0.30.1"
 
 name: rasa-x

--- a/charts/rasa-x/templates/app-deployment.yaml
+++ b/charts/rasa-x/templates/app-deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     {{- include "rasa-x.labels" . | nindent 4 }}
     app.kubernetes.io/component: app
+  annotations:
+    sidecar.jaegertracing.io/inject: "{{ $.Values.app.jaegerSidecar }}"
 spec:
   progressDeadlineSeconds: {{ .Values.global.progressDeadlineSeconds }}
   replicas: {{ default 1 .Values.app.replicaCount }}

--- a/charts/rasa-x/templates/rasa-config-files-configmap.yaml
+++ b/charts/rasa-x/templates/rasa-config-files-configmap.yaml
@@ -55,3 +55,6 @@ data:
       password: ${REDIS_PASSWORD}
       db: {{ default "1" .Values.rasa.lockStoreDatabase }}
     {{- end }}
+    {{- with .Values.rasa.additionalEndpoints }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}

--- a/charts/rasa-x/templates/rasa-deployments.yaml
+++ b/charts/rasa-x/templates/rasa-deployments.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     {{- include "rasa-x.labels" $ | nindent 4 }}
     app.kubernetes.io/component: {{ .serviceName }}
+  annotations:
+    sidecar.jaegertracing.io/inject: "{{ $.Values.rasa.jaegerSidecar }}"
 spec:
   progressDeadlineSeconds: {{ $.Values.global.progressDeadlineSeconds }}
   replicas: {{ default 1 .replicaCount }}

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -25,6 +25,8 @@ rasax:
   databaseName: ""
   # disableTelemetry permanently disables telemetry
   disableTelemetry: false
+  # Jaeger Sidecar
+  jaegerSidecar: "false"
   # initialUser is the user which is created upon the initial start of Rasa X
   initialUser:
     # username specifies a name of this user
@@ -103,6 +105,13 @@ rasa:
     #   verify: "rasa-bot"
     #   secret: "3e34709d01ea89032asdebfe5a74518"
     #   page-access-token: "EAAbHPa7H9rEBAAuFk4Q3gPKbDedQnx4djJJ1JmQ7CAqO4iJKrQcNT0wtD"
+  # input channels
+  additionalEndpoints: {}
+    # telemetry:
+    #   type: jaeger
+    #   service_name: rasa
+  # Jaeger Sidecar
+  jaegerSidecar: "false"
   # initialProbeDelay for the `readinessProbe` and the `livenessProbe`
   initialProbeDelay: 10
   # useLoginDatabase will use the Rasa X database to log in and create the database
@@ -246,6 +255,8 @@ app:
   port: 5055
   # resources which app is required / allowed to use
   resources: {}
+  # Jaeger Sidecar
+  jaegerSidecar: "false"
   # extraEnvs are environment variables which can be added to the app deployment
   extraEnvs: []
   #  - name: DATABASE_URL


### PR DESCRIPTION
Add support for the Jaeger sidecar [annotation](https://www.jaegertracing.io/docs/1.20/operator/#auto-injecting-jaeger-agent-sidecars) used by the [Jaeger Kubernetes Operator](https://www.jaegertracing.io/docs/1.20/operator/) as described in #88