### PR TITLE
avoid 'arg' being specified twice

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 
 
-version: "1.6.11"
+version: "1.6.12"
 appVersion: "0.30.1"
 
 name: rasa-x

--- a/charts/rasa-x/templates/event-service-deployment.yaml
+++ b/charts/rasa-x/templates/event-service-deployment.yaml
@@ -37,10 +37,14 @@ spec:
         command:
           {{- toYaml .Values.eventService.command | nindent 10 }}
         {{- end }}
-        {{- if .Values.eventService.args }}
         args:
+          {{- if .Values.eventService.args }}
           {{- toYaml .Values.eventService.args | nindent 10 }}
-        {{- end }}
+          {{- else }}
+          - python
+          - -m
+          - rasax.community.services.event_service
+          {{- end }}
         ports:
           - name: "http"
             containerPort: {{ default 5673 .Values.eventService.port }}
@@ -53,10 +57,6 @@ spec:
           httpGet:
             path: "/health"
             port: "http"
-        args:
-          - python
-          - -m
-          - rasax.community.services.event_service
         env:
         {{- if eq "true" (include "is_enterprise" .) }}
         - name: "RASA_TELEMETRY_ENABLED"


### PR DESCRIPTION
**Proposed Changes**:
Only use default `args` if no custom `args` are defined. Otherwise this can lead to a duplicate yaml key error