### PR TITLE
Increase proxy read timeout and proxy send timeout for nginx-ingress

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 
 
-version: "1.6.12"
+version: "1.6.13"
 appVersion: "0.30.1"
 
 name: rasa-x

--- a/charts/rasa-x/templates/rasa-open-source-ingress.yaml
+++ b/charts/rasa-x/templates/rasa-open-source-ingress.yaml
@@ -15,6 +15,9 @@ metadata:
   {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.ingress.annotationsRasa }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
 {{- if .Values.ingress.tls }}
   tls:

--- a/charts/rasa-x/templates/rasa-x-ingress.yaml
+++ b/charts/rasa-x/templates/rasa-x-ingress.yaml
@@ -13,8 +13,8 @@ metadata:
     {{- include "rasa-x.labels" . | nindent 4 }}
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       if ($arg_environment = "") {
           rewrite ^/api/chat$ /core/webhooks/rasa/webhook last;

--- a/charts/rasa-x/templates/rasa-x-ingress.yaml
+++ b/charts/rasa-x/templates/rasa-x-ingress.yaml
@@ -12,9 +12,12 @@ metadata:
   labels:
     {{- include "rasa-x.labels" . | nindent 4 }}
   annotations:
-    nginx.ingress.kubernetes.io/proxy-body-size: "0"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+  {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.ingress.annotationsRasaX }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
     nginx.ingress.kubernetes.io/configuration-snippet: |
       if ($arg_environment = "") {
           rewrite ^/api/chat$ /core/webhooks/rasa/webhook last;

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -476,10 +476,17 @@ ingress:
   # Note that if `nginx.enabled` is `true` the `rasa/nginx` image is used as reverse proxy.
   # In order to use nginx ingress you have to set `nginx.enabled=false`.
   enabled: true
-  # annotations for the ingress
+  # annotations for the ingress - annotations are applied for the rasa and rasax ingresses
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  # annotationsRasa is extra annotations for the rasa nginx ingress
+  annotationsRasa: {}
+  # annotationsRasaX is extra annotations for the rasa x nginx ingress
+  annotationsRasaX:
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
   # hosts for this ingress
   hosts:
     - host: rasa-x.example.com


### PR DESCRIPTION
Increase timeout for the proxy send and proxy read to 3600 seconds for the nginx ingress configuration. 