### PR TITLE
Disable telemetry for the DB migration service

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "1.7.1"
+version: "1.7.2"
 appVersion: "0.33.0"
 
 name: rasa-x

--- a/charts/rasa-x/templates/_helpers.tpl
+++ b/charts/rasa-x/templates/_helpers.tpl
@@ -273,3 +273,10 @@ initContainers:
     echo The database migration status: completed...100%"
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the rasa x image name value as a default if the dbMigrationService.name variable is not defined.
+*/}}
+{{- define "dbMigrationService-name" -}}
+{{ .Values.dbMigrationService.name | default .Values.rasax.name }}
+{{- end -}}

--- a/charts/rasa-x/templates/db-migration-service-deployment.yaml
+++ b/charts/rasa-x/templates/db-migration-service-deployment.yaml
@@ -31,7 +31,7 @@ spec:
       {{- end }}
       containers:
       - name: db-migration-service
-        image: "{{ .Values.dbMigrationService.name }}:{{ include "db-migration-service.version" . }}"
+        image: "{{ include "dbMigrationService-name" . }}:{{ include "db-migration-service.version" . }}"
         imagePullPolicy: {{ .Values.images.pullPolicy }}
         {{- if .Values.dbMigrationService.command }}
         command:
@@ -61,10 +61,8 @@ spec:
 {{ toYaml .Values.dbMigrationService.extraVolumeMounts | indent 8 }}
 {{- end }}
         env:
-        {{- if contains "rasa-x-ee" .Values.dbMigrationService.name }}
         - name: "RASA_TELEMETRY_ENABLED"
           value: "false"
-        {{ end }}
         - name: "SELF_PORT"
           value: {{ .Values.dbMigrationService.port | quote }}
         - name: "RUN_DATABASE_MIGRATION_AS_SEPARATE_SERVICE"

--- a/charts/rasa-x/templates/db-migration-service-deployment.yaml
+++ b/charts/rasa-x/templates/db-migration-service-deployment.yaml
@@ -61,6 +61,10 @@ spec:
 {{ toYaml .Values.dbMigrationService.extraVolumeMounts | indent 8 }}
 {{- end }}
         env:
+        {{- if contains "rasa-x-ee" .Values.dbMigrationService.name }}
+        - name: "RASA_TELEMETRY_ENABLED"
+          value: "false"
+        {{ end }}
         - name: "SELF_PORT"
           value: {{ .Values.dbMigrationService.port | quote }}
         - name: "RUN_DATABASE_MIGRATION_AS_SEPARATE_SERVICE"

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -206,8 +206,8 @@ dbMigrationService:
   command: []
   # args overrides the default arguments to run in the container
   args: []
-  # name is the Docker image name which is used by the migration service
-  name: "rasa/rasa-x"  # gcr.io/rasa-platform/rasa-x-ee
+  # name is the Docker image name which is used by the migration service (uses `rasax.name` by default)
+  name: ""  # gcr.io/rasa-platform/rasa-x-ee
   # tag refers to the Rasa X image tag (uses `appVersion` by default)
   tag: ""
   # ignoreVersionCheck defines if check required minimum Rasa X version that is required to run the service


### PR DESCRIPTION
Disable telemetry for the DB migration service if the Enterprise version is used. 