### PR TITLE
support non semantic Rasa image tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ recommend to set at least these values:
 | `global.postgresql.postgresqlPassword` | Password for the Postgresql database.                                                      | `password`         |
 | `global.redis.password`                | Password for redis.                                                                        | `password`         |
 | `rasax.tag`                            | Version of Rasa X which you want to use.                                                   | `0.29.1`           |
-| `rasa.version`                         | Version of Rasa Open Source which you want to use.                                         | `1.10.3`           |
+| `rasa.version`                         | Version of Rasa Open Source which you want to use.                                         | `2.0.3`            |
 | `rasa.tag`                             | Image tag which should be used for Rasa Open Source. Uses `rasa.version` if empty          | ``                 |
 | `app.name`                             | Name of your action server image.                                                          | `rasa/rasa-x-demo` |
 | `app.tag`                              | Tag of your action server image.                                                           | `0.29.1`           |

--- a/README.md
+++ b/README.md
@@ -39,36 +39,36 @@ helm delete <your release name>
 All configurable values are documented in `values.yaml`. For a quick installation we
 recommend to set at least these values:
 
-| Parameter                            | Description                                                                                | Default              |
-|--------------------------------------|--------------------------------------------------------------------------------------------|----------------------|
+| Parameter                            | Description                                                                                  | Default            |
+|--------------------------------------|----------------------------------------------------------------------------------------------|--------------------|
 | `rasax.passwordSalt`                   | Password salt which Rasa X uses for the user passwords.                                    | `passwordSalt`     |
 | `rasax.token`                          | Token which the Rasa X pod uses to authenticate requests from other pods.                  | `rasaXToken`       |
-| `rasax.command`                        | Override the default command to run in the container                                       | `[]`               |
-| `rasax.args`                           | Override the default arguments to run in the container                                     | `[]`               |
+| `rasax.command`                        | Override the default command to run in the container.                                      | `[]`               |
+| `rasax.args`                           | Override the default arguments to run in the container.                                    | `[]`               |
 | `rasax.jwtSecret`                      | Secret which is used to sign JWT tokens of Rasa X users.                                   | `jwtSecret`        |
-| `rasax.initialUser.username`           | **Only for Rasa Enterprise**. A name of the user that will be created immediately after the first launch (`rasax.initialUser.password` should be specified) | `admin`            |
+| `rasax.initialUser.username`           | **Only for Rasa Enterprise**. A name of the user that will be created immediately after the first launch (`rasax.initialUser.password` should be specified). | `admin`            |
 | `rasax.initialUser.password`           | Password for the initial user. If you use Rasa Enterprise and leave it empty, no users will be created. If you use Rasa CE and leave it empty, the password will be generated automatically. | `""`               |
 | `rasa.token`                           | Token which the Rasa pods use to authenticate requests from other pods.                    | `rasaToken`        |
-| `rasa.command`                         | Override the default command to run in the container                                       | `[]`               |
-| `rasa.args`                            | Override the default arguments to run in the container                                     | `[]`               |
-| `rasa.extraArgs`                       | Additional rasa arguments                                                                  | `[]`               |
+| `rasa.command`                         | Override the default command to run in the container.                                      | `[]`               |
+| `rasa.args`                            | Override the default arguments to run in the container.                                    | `[]`               |
+| `rasa.extraArgs`                       | Additional rasa arguments.                                                                 | `[]`               |
 | `rabbitmq.rabbitmq.password`           | Password for RabbitMq.                                                                     | `test`             |
 | `global.postgresql.postgresqlPassword` | Password for the Postgresql database.                                                      | `password`         |
 | `global.redis.password`                | Password for redis.                                                                        | `password`         |
 | `rasax.tag`                            | Version of Rasa X which you want to use.                                                   | `0.29.1`           |
 | `rasa.version`                         | Version of Rasa Open Source which you want to use.                                         | `2.0.3`            |
-| `rasa.tag`                             | Image tag which should be used for Rasa Open Source. Uses `rasa.version` if empty          | ``                 |
+| `rasa.tag`                             | Image tag which should be used for Rasa Open Source. Uses `rasa.version` if empty.         | ``                 |
 | `app.name`                             | Name of your action server image.                                                          | `rasa/rasa-x-demo` |
 | `app.tag`                              | Tag of your action server image.                                                           | `0.29.1`           |
-| `app.command`                          | Override the default command to run in the container                                       | `[]`               |
-| `app.args`                             | Override the default arguments to run in the container                                     | `[]`               |
-| `eventService.command`                 | Override the default command to run in the container                                       | `[]`               |
-| `eventService.args`                    | Override the default arguments to run in the container                                     | `[]`               |
-| `nginx.command`                        | Override the default command to run in the container                                       | `[]`               |
-| `nginx.args`                           | Override the default arguments to run in the container                                     | `[]`               |
-| `duckling.command`                     | Override the default command to run in the container                                       | `[]`               |
-| `duckling.args`                        | Override the default arguments to run in the container                                     | `[]`               |
-| `global.progressDeadlineSeconds`       | Specifies the number of seconds you want to wait for your Deployment to progress before the system reports back that the Deployment has failed progressing | `600` |
+| `app.command`                          | Override the default command to run in the container.                                      | `[]`               |
+| `app.args`                             | Override the default arguments to run in the container.                                    | `[]`               |
+| `eventService.command`                 | Override the default command to run in the container.                                      | `[]`               |
+| `eventService.args`                    | Override the default arguments to run in the container.                                    | `[]`               |
+| `nginx.command`                        | Override the default command to run in the container.                                      | `[]`               |
+| `nginx.args`                           | Override the default arguments to run in the container.                                    | `[]`               |
+| `duckling.command`                     | Override the default command to run in the container.                                      | `[]`               |
+| `duckling.args`                        | Override the default arguments to run in the container.                                    | `[]`               |
+| `global.progressDeadlineSeconds`       | Specifies the number of seconds you want to wait for your Deployment to progress before the system reports back that the Deployment has failed progressing. | `600` |
 
 ## Where to get help
 

--- a/README.md
+++ b/README.md
@@ -39,34 +39,35 @@ helm delete <your release name>
 All configurable values are documented in `values.yaml`. For a quick installation we
 recommend to set at least these values:
 
-| Parameter                            | Description                                                                                | Default            |
-|--------------------------------------|--------------------------------------------------------------------------------------------|--------------------|
+| Parameter                            | Description                                                                                | Default              |
+|--------------------------------------|--------------------------------------------------------------------------------------------|----------------------|
 | `rasax.passwordSalt`                   | Password salt which Rasa X uses for the user passwords.                                    | `passwordSalt`     |
 | `rasax.token`                          | Token which the Rasa X pod uses to authenticate requests from other pods.                  | `rasaXToken`       |
-| `rasax.command`                        | Override the default command to run in the container                                       | `[]`              |
-| `rasax.args`                           | Override the default arguments to run in the container                                     | `[]`              |
-| `rasax.jwtSecret`                      | Secret which is used to sign JWT tokens of Rasa X users.                           | `jwtSecret`        |
+| `rasax.command`                        | Override the default command to run in the container                                       | `[]`               |
+| `rasax.args`                           | Override the default arguments to run in the container                                     | `[]`               |
+| `rasax.jwtSecret`                      | Secret which is used to sign JWT tokens of Rasa X users.                                   | `jwtSecret`        |
 | `rasax.initialUser.username`           | **Only for Rasa Enterprise**. A name of the user that will be created immediately after the first launch (`rasax.initialUser.password` should be specified) | `admin`            |
 | `rasax.initialUser.password`           | Password for the initial user. If you use Rasa Enterprise and leave it empty, no users will be created. If you use Rasa CE and leave it empty, the password will be generated automatically. | `""`               |
 | `rasa.token`                           | Token which the Rasa pods use to authenticate requests from other pods.                    | `rasaToken`        |
-| `rasa.command`                         | Override the default command to run in the container                                       | `[]`              |
-| `rasa.args`                            | Override the default arguments to run in the container                                     | `[]`              |
-| `rasa.extraArgs`                       | Additional rasa arguments                                                                  | `[]`              |
+| `rasa.command`                         | Override the default command to run in the container                                       | `[]`               |
+| `rasa.args`                            | Override the default arguments to run in the container                                     | `[]`               |
+| `rasa.extraArgs`                       | Additional rasa arguments                                                                  | `[]`               |
 | `rabbitmq.rabbitmq.password`           | Password for RabbitMq.                                                                     | `test`             |
 | `global.postgresql.postgresqlPassword` | Password for the Postgresql database.                                                      | `password`         |
 | `global.redis.password`                | Password for redis.                                                                        | `password`         |
 | `rasax.tag`                            | Version of Rasa X which you want to use.                                                   | `0.29.1`           |
-| `rasa.tag`                             | Version of Rasa OSS which you want to use.                                                 | `1.10.3`           |
+| `rasa.version`                         | Version of Rasa Open Source which you want to use.                                         | `1.10.3`           |
+| `rasa.tag`                             | Image tag which should be used for Rasa Open Source. Uses `rasa.version` if empty          | ``                 |
 | `app.name`                             | Name of your action server image.                                                          | `rasa/rasa-x-demo` |
 | `app.tag`                              | Tag of your action server image.                                                           | `0.29.1`           |
-| `app.command`                          | Override the default command to run in the container                                       | `[]`              |
-| `app.args`                             | Override the default arguments to run in the container                                     | `[]`              |
-| `eventService.command`                 | Override the default command to run in the container                                       | `[]`              |
-| `eventService.args`                    | Override the default arguments to run in the container                                     | `[]`              |
-| `nginx.command`                        | Override the default command to run in the container                                       | `[]`              |
-| `nginx.args`                           | Override the default arguments to run in the container                                     | `[]`              |
-| `duckling.command`                     | Override the default command to run in the container                                       | `[]`              |
-| `duckling.args`                        | Override the default arguments to run in the container                                     | `[]`              |
+| `app.command`                          | Override the default command to run in the container                                       | `[]`               |
+| `app.args`                             | Override the default arguments to run in the container                                     | `[]`               |
+| `eventService.command`                 | Override the default command to run in the container                                       | `[]`               |
+| `eventService.args`                    | Override the default arguments to run in the container                                     | `[]`               |
+| `nginx.command`                        | Override the default command to run in the container                                       | `[]`               |
+| `nginx.args`                           | Override the default arguments to run in the container                                     | `[]`               |
+| `duckling.command`                     | Override the default command to run in the container                                       | `[]`               |
+| `duckling.args`                        | Override the default arguments to run in the container                                     | `[]`               |
 | `global.progressDeadlineSeconds`       | Specifies the number of seconds you want to wait for your Deployment to progress before the system reports back that the Deployment has failed progressing | `600` |
 
 ## Where to get help

--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "1.7.1"
+version: "1.7.2"
 appVersion: "0.33.0"
 
 name: rasa-x

--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "1.7.2"
+version: "1.7.3"
 appVersion: "0.33.0"
 
 name: rasa-x

--- a/charts/rasa-x/templates/_helpers.tpl
+++ b/charts/rasa-x/templates/_helpers.tpl
@@ -210,6 +210,14 @@ Return the AppVersion value as a default if the app.tag variable is not defined.
 {{- end -}}
 
 {{/*
+Return the Rasa image tag. Use `.Values.rasa.version` if `Values.rasa.tag` is not defined.
+*/}}
+{{- define "rasa.tag" -}}
+{{ .Values.rasa.tag | default (printf "%s-full" .Values.rasa.version) }}
+{{- end -}}
+
+
+{{/*
 Return 'true' if an enterprise version is run.
 */}}
 {{- define "is_enterprise" -}}

--- a/charts/rasa-x/templates/_helpers.tpl
+++ b/charts/rasa-x/templates/_helpers.tpl
@@ -216,7 +216,6 @@ Return the Rasa image tag. Use `.Values.rasa.version` if `Values.rasa.tag` is no
 {{ .Values.rasa.tag | default (printf "%s-full" .Values.rasa.version) }}
 {{- end -}}
 
-
 {{/*
 Return 'true' if an enterprise version is run.
 */}}

--- a/charts/rasa-x/templates/rasa-config-files-configmap.yaml
+++ b/charts/rasa-x/templates/rasa-config-files-configmap.yaml
@@ -33,11 +33,11 @@ data:
       username: "{{ .Values.rabbitmq.rabbitmq.username }}"
       password: ${RABBITMQ_PASSWORD}
       port: {{ default 5672 .Values.rabbitmq.service.port }}
-      {{ if or (regexMatch ".*(a|rc)[0-9]+" .Values.rasa.tag) (regexMatch "2.*[0-9]+-full" .Values.rasa.tag) -}}
+      {{ if or (regexMatch ".*(a|rc)[0-9]+" .Values.rasa.version) (regexMatch "2.*[0-9]+-full" .Values.rasa.version) -}}
       queues:
       - ${RABBITMQ_QUEUE}
       {{- else -}}
-      {{ if semverCompare ">= 1.9.0" .Values.rasa.tag -}}
+      {{ if semverCompare ">= 1.9.0" .Values.rasa.version -}}
       queues:
       - ${RABBITMQ_QUEUE}
       {{- else -}}

--- a/charts/rasa-x/templates/rasa-deployments.yaml
+++ b/charts/rasa-x/templates/rasa-deployments.yaml
@@ -41,7 +41,7 @@ spec:
       {{- include "initContainer.dbMigration" $ |  nindent 6 }}
       containers:
       - name: {{ $.Chart.Name }}
-        image: "{{ $.Values.rasa.name }}:{{ $.Values.rasa.tag }}"
+        image: '{{ $.Values.rasa.name }}:{{ include "rasa.tag" $ }}'
         imagePullPolicy: {{ $.Values.images.pullPolicy }}
         ports:
         - name: "http"

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -83,7 +83,7 @@ rasax:
 rasa:
   # version is the Rasa Open Source version which should be used
   # Used to ensure backward compatibility
-  version: "1.10.3" # Please check the README to see all locations which have to be updated for a rasa release)
+  version: "2.0.3" # Please check the README to see all locations which have to be updated for a rasa release)
   # override the default command to run in the container
   command: []
   # override the default arguments to run in the container

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -81,9 +81,9 @@ rasax:
 
 # rasa: Settings common for all Rasa containers
 rasa:
-  # version is the Rasa Open Source version which should be used
-  # Used to ensure backward compatibility
-  version: "2.0.3" # Please check the README to see all locations which have to be updated for a rasa release)
+  # version is the Rasa Open Source version which should be used.
+  # Used to ensure backward compatibility with older Rasa Open Source versions.
+  version: "2.0.3" # Please update the default value in the Readme when updating this
   # override the default command to run in the container
   command: []
   # override the default arguments to run in the container
@@ -92,7 +92,7 @@ rasa:
   extraArgs: []
   # name of the Rasa image to use
   name: "rasa/rasa"
-  # tag refers to the Rasa image tag. If empty `.Values.rasa.version` is used.
+  # tag refers to the Rasa image tag. If empty `.Values.rasa.version-full` is used.
   tag: ""
   # port on which Rasa runs
   port: 5005

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -83,7 +83,7 @@ rasax:
 rasa:
   # version is the Rasa Open Source version which should be used.
   # Used to ensure backward compatibility with older Rasa Open Source versions.
-  version: "2.0.3" # Please update the default value in the Readme when updating this
+  version: "2.0.3"  # Please update the default value in the Readme when updating this
   # override the default command to run in the container
   command: []
   # override the default arguments to run in the container

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -81,6 +81,9 @@ rasax:
 
 # rasa: Settings common for all Rasa containers
 rasa:
+  # version is the Rasa Open Source version which should be used
+  # Used to ensure backward compatibility
+  version: "1.10.3" # Please check the README to see all locations which have to be updated for a rasa release)
   # override the default command to run in the container
   command: []
   # override the default arguments to run in the container
@@ -89,8 +92,8 @@ rasa:
   extraArgs: []
   # name of the Rasa image to use
   name: "rasa/rasa"
-  # tag refers to the Rasa image tag
-  tag: "1.10.3"  # Please check the README to see all locations which have to be updated for a rasa release)
+  # tag refers to the Rasa image tag. If empty `.Values.rasa.version` is used.
+  tag: ""
   # port on which Rasa runs
   port: 5005
   # token Rasa accepts as authentication token from other Rasa services


### PR DESCRIPTION
**Proposed Changes**:
- fix https://github.com/RasaHQ/rasa-x-helm/issues/86
- introduce a new `.rasa.version` value which is used to the version checks to ensure backward compatibility. This is only used to construct the image tag in case `.Values.rasa.tag` is empty. If `Values.rasa.tag` is empty, a template constructs an image name `{.Values.rasa.version}-full` by default. 