### PR TITLE
make scheme of live/readiness probes configurable

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "1.7.5"
+version: "1.7.6"
 appVersion: "0.33.0"
 
 name: rasa-x

--- a/charts/rasa-x/templates/app-deployment.yaml
+++ b/charts/rasa-x/templates/app-deployment.yaml
@@ -50,12 +50,12 @@ spec:
           httpGet:
             path: "{{ .Values.app.endpoints.healthCheckUrl }}"
             port: "http"
-            scheme: {{ default "HTTP" .Values.app.probeScheme }}
+            scheme: {{ default "HTTP" .Values.app.livenessProbe.scheme }}
         readinessProbe:
           httpGet:
             path: "{{ .Values.app.endpoints.healthCheckUrl }}"
             port: "http"
-            scheme: {{ default "HTTP" .Values.app.probeScheme }}
+            scheme: {{ default "HTTP" .Values.app.readinessProbe.scheme }}
         {{- with .Values.app.resources }}
         resources:
           {{- toYaml . | nindent 10 }}

--- a/charts/rasa-x/templates/app-deployment.yaml
+++ b/charts/rasa-x/templates/app-deployment.yaml
@@ -50,10 +50,12 @@ spec:
           httpGet:
             path: "{{ .Values.app.endpoints.healthCheckUrl }}"
             port: "http"
+            scheme: {{ default "HTTP" .Values.app.probeScheme }}
         readinessProbe:
           httpGet:
             path: "{{ .Values.app.endpoints.healthCheckUrl }}"
             port: "http"
+            scheme: {{ default "HTTP" .Values.app.probeScheme }}
         {{- with .Values.app.resources }}
         resources:
           {{- toYaml . | nindent 10 }}

--- a/charts/rasa-x/templates/db-migration-service-deployment.yaml
+++ b/charts/rasa-x/templates/db-migration-service-deployment.yaml
@@ -52,10 +52,12 @@ spec:
           httpGet:
             path: "/health"
             port: "http"
+            scheme: {{ default "HTTP" .Values.dbMigrationService.probeScheme }}
         readinessProbe:
           httpGet:
             path: "/health"
             port: "http"
+            scheme: {{ default "HTTP" .Values.dbMigrationService.probeScheme }}
 {{- if .Values.dbMigrationService.extraVolumeMounts }}
         volumeMounts:
 {{ toYaml .Values.dbMigrationService.extraVolumeMounts | indent 8 }}

--- a/charts/rasa-x/templates/db-migration-service-deployment.yaml
+++ b/charts/rasa-x/templates/db-migration-service-deployment.yaml
@@ -52,12 +52,12 @@ spec:
           httpGet:
             path: "/health"
             port: "http"
-            scheme: {{ default "HTTP" .Values.dbMigrationService.probeScheme }}
+            scheme: {{ default "HTTP" .Values.dbMigrationService.livenessProbe.scheme }}
         readinessProbe:
           httpGet:
             path: "/health"
             port: "http"
-            scheme: {{ default "HTTP" .Values.dbMigrationService.probeScheme }}
+            scheme: {{ default "HTTP" .Values.dbMigrationService.readinessProbe.scheme }}
 {{- if .Values.dbMigrationService.extraVolumeMounts }}
         volumeMounts:
 {{ toYaml .Values.dbMigrationService.extraVolumeMounts | indent 8 }}

--- a/charts/rasa-x/templates/duckling-deployment.yaml
+++ b/charts/rasa-x/templates/duckling-deployment.yaml
@@ -49,12 +49,12 @@ spec:
           httpGet:
             path: "/"
             port: "http"
-            scheme: {{ default "HTTP" .Values.duckling.probeScheme }}
+            scheme: {{ default "HTTP" .Values.duckling.livenessProbe.scheme }}
         readinessProbe:
           httpGet:
             path: "/"
             port: "http"
-            scheme: {{ default "HTTP" .Values.duckling.probeScheme }}
+            scheme: {{ default "HTTP" .Values.duckling.readinessProbe.scheme }}
         {{- with .Values.duckling.resources }}
         resources:
           {{- toYaml . | nindent 10 }}

--- a/charts/rasa-x/templates/duckling-deployment.yaml
+++ b/charts/rasa-x/templates/duckling-deployment.yaml
@@ -49,10 +49,12 @@ spec:
           httpGet:
             path: "/"
             port: "http"
+            scheme: {{ default "HTTP" .Values.duckling.probeScheme }}
         readinessProbe:
           httpGet:
             path: "/"
             port: "http"
+            scheme: {{ default "HTTP" .Values.duckling.probeScheme }}
         {{- with .Values.duckling.resources }}
         resources:
           {{- toYaml . | nindent 10 }}

--- a/charts/rasa-x/templates/event-service-deployment.yaml
+++ b/charts/rasa-x/templates/event-service-deployment.yaml
@@ -57,10 +57,12 @@ spec:
           httpGet:
             path: "/health"
             port: "http"
+            scheme: {{ default "HTTP" .Values.eventService.probeScheme }}
         readinessProbe:
           httpGet:
             path: "/health"
             port: "http"
+            scheme: {{ default "HTTP" .Values.eventService.probeScheme }}
         env:
         {{- if eq "true" (include "is_enterprise" .) }}
         - name: "RASA_TELEMETRY_ENABLED"

--- a/charts/rasa-x/templates/event-service-deployment.yaml
+++ b/charts/rasa-x/templates/event-service-deployment.yaml
@@ -57,12 +57,12 @@ spec:
           httpGet:
             path: "/health"
             port: "http"
-            scheme: {{ default "HTTP" .Values.eventService.probeScheme }}
+            scheme: {{ default "HTTP" .Values.eventService.livenessProbe.scheme }}
         readinessProbe:
           httpGet:
             path: "/health"
             port: "http"
-            scheme: {{ default "HTTP" .Values.eventService.probeScheme }}
+            scheme: {{ default "HTTP" .Values.eventService.readinessProbe.scheme }}
         env:
         {{- if eq "true" (include "is_enterprise" .) }}
         - name: "RASA_TELEMETRY_ENABLED"

--- a/charts/rasa-x/templates/rasa-deployments.yaml
+++ b/charts/rasa-x/templates/rasa-deployments.yaml
@@ -47,7 +47,6 @@ spec:
         - name: "http"
           containerPort: {{ default 5005 $.Values.rasa.port }}
           protocol: "TCP"
-          scheme: {{ default "HTTP" $.Values.rasa.probeScheme }}
         livenessProbe:
           httpGet:
             path: "/"

--- a/charts/rasa-x/templates/rasa-deployments.yaml
+++ b/charts/rasa-x/templates/rasa-deployments.yaml
@@ -47,10 +47,12 @@ spec:
         - name: "http"
           containerPort: {{ default 5005 $.Values.rasa.port }}
           protocol: "TCP"
+          scheme: {{ default "HTTP" $.Values.rasaa.probeScheme }}
         livenessProbe:
           httpGet:
             path: "/"
             port: "http"
+            scheme: {{ default "HTTP" $.Values.rasa.probeScheme }}
           initialDelaySeconds: {{ $.Values.rasa.initialProbeDelay }}
           failureThreshold: 10
         {{- if $.Values.rasa.command }}

--- a/charts/rasa-x/templates/rasa-deployments.yaml
+++ b/charts/rasa-x/templates/rasa-deployments.yaml
@@ -47,7 +47,7 @@ spec:
         - name: "http"
           containerPort: {{ default 5005 $.Values.rasa.port }}
           protocol: "TCP"
-          scheme: {{ default "HTTP" $.Values.rasaa.probeScheme }}
+          scheme: {{ default "HTTP" $.Values.rasa.probeScheme }}
         livenessProbe:
           httpGet:
             path: "/"

--- a/charts/rasa-x/templates/rasa-deployments.yaml
+++ b/charts/rasa-x/templates/rasa-deployments.yaml
@@ -51,7 +51,7 @@ spec:
           httpGet:
             path: "/"
             port: "http"
-            scheme: {{ default "HTTP" $.Values.rasa.probeScheme }}
+            scheme: {{ default "HTTP" $.Values.rasa.livenessProbe.scheme }}
           initialDelaySeconds: {{ $.Values.rasa.initialProbeDelay }}
           failureThreshold: 10
         {{- if $.Values.rasa.command }}

--- a/charts/rasa-x/templates/rasa-services.yaml
+++ b/charts/rasa-x/templates/rasa-services.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{ include "rasa-x.labels" $ | nindent 4 }}
     app.kubernetes.io/component: {{ .serviceName }}
-{{- with .Values.rasa.service.annotations }}
+{{- with $.Values.rasa.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
 {{- end }}

--- a/charts/rasa-x/templates/rasa-x-deployment.yaml
+++ b/charts/rasa-x/templates/rasa-x-deployment.yaml
@@ -54,14 +54,14 @@ spec:
           httpGet:
             path: "/"
             port: "http"
-            scheme: {{ default "HTTP" .Values.rasax.probeScheme }}
+            scheme: {{ default "HTTP" .Values.rasax.livenessProbe.scheme }}
           initialDelaySeconds: {{ .Values.rasax.initialProbeDelay }}
           failureThreshold: 10
         readinessProbe:
           httpGet:
             path: "/"
             port: "http"
-            scheme: {{ default "HTTP" .Values.rasax.probeScheme }}
+            scheme: {{ default "HTTP" .Values.readinessProbe.scheme }}
           initialDelaySeconds: {{ .Values.rasax.initialProbeDelay }}
           failureThreshold: 10
         env:

--- a/charts/rasa-x/templates/rasa-x-deployment.yaml
+++ b/charts/rasa-x/templates/rasa-x-deployment.yaml
@@ -61,7 +61,7 @@ spec:
           httpGet:
             path: "/"
             port: "http"
-            scheme: {{ default "HTTP" .Values.readinessProbe.scheme }}
+            scheme: {{ default "HTTP" .Values.rasax.readinessProbe.scheme }}
           initialDelaySeconds: {{ .Values.rasax.initialProbeDelay }}
           failureThreshold: 10
         env:

--- a/charts/rasa-x/templates/rasa-x-deployment.yaml
+++ b/charts/rasa-x/templates/rasa-x-deployment.yaml
@@ -50,10 +50,12 @@ spec:
           - name: "http"
             containerPort: {{ default 5002 .Values.rasax.port }}
             protocol: "TCP"
+            scheme: {{ default "HTTP" .Values.rasax.probeScheme }}
         livenessProbe:
           httpGet:
             path: "/"
             port: "http"
+            scheme: {{ default "HTTP" .Values.rasax.probeScheme }}
           initialDelaySeconds: {{ .Values.rasax.initialProbeDelay }}
           failureThreshold: 10
         readinessProbe:

--- a/charts/rasa-x/templates/rasa-x-deployment.yaml
+++ b/charts/rasa-x/templates/rasa-x-deployment.yaml
@@ -50,7 +50,6 @@ spec:
           - name: "http"
             containerPort: {{ default 5002 .Values.rasax.port }}
             protocol: "TCP"
-            scheme: {{ default "HTTP" .Values.rasax.probeScheme }}
         livenessProbe:
           httpGet:
             path: "/"
@@ -62,6 +61,7 @@ spec:
           httpGet:
             path: "/"
             port: "http"
+            scheme: {{ default "HTTP" .Values.rasax.probeScheme }}
           initialDelaySeconds: {{ .Values.rasax.initialProbeDelay }}
           failureThreshold: 10
         env:

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -51,8 +51,14 @@ rasax:
     existingClaim: ""
   # initialProbeDelay for the `readinessProbe` and the `livenessProbe`
   initialProbeDelay: 10
-  # scheme to be used by the `readinessProbe` and the `livenessProbe`
-  probeScheme: "HTTP"
+  # livenessProbe checks whether rasa x needs to be restarted
+  livenessProbe:
+    # scheme to be used by the `readinessProbe`
+    scheme: "HTTP"
+  # readinessProbe checks whether rasa x can receive traffic
+  readinessProbe:
+    # scheme to be used by the `readinessProbe`
+    scheme: "HTTP"
   # resources which Rasa X is required / allowed to use
   resources: {}
   # extraEnvs are environment variables which can be added to the Rasa X deployment
@@ -127,10 +133,12 @@ rasa:
     #   service_name: rasa
   # Jaeger Sidecar
   jaegerSidecar: "false"
-  # initialProbeDelay for the `readinessProbe` and the `livenessProbe`
+  # initialProbeDelay for the `livenessProbe`
   initialProbeDelay: 10
-  # scheme to be used by the `livenessProbe`
-  probeScheme: "HTTP"
+  # livenessProbe checks whether rasa needs to be restarted
+  livenessProbe:
+    # scheme to be used by the `readinessProbe`
+    scheme: "HTTP"
   # useLoginDatabase will use the Rasa X database to log in and create the database
   # for the tracker store. If `false` the tracker store database must have been created
   # previously.
@@ -280,8 +288,14 @@ dbMigrationService:
     # annotations for the service
     annotations: {}
 
-  # scheme to be used by the `readinessProbe` and the `livenessProbe`
-  probeScheme: "HTTP"
+  # livenessProbe checks whether the db migration service needs to be restarted
+  livenessProbe:
+    # scheme to be used by the `readinessProbe`
+    scheme: "HTTP"
+  # readinessProbe checks whether the db migration service can receive traffic
+  readinessProbe:
+    # scheme to be used by the `readinessProbe`
+    scheme: "HTTP"
 
 # event-service specific settings
 eventService:
@@ -333,8 +347,14 @@ eventService:
   # https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server
   automountServiceAccountToken: false
 
-  # scheme to be used by the `readinessProbe` and the `livenessProbe`
-  probeScheme: "HTTP"
+  # livenessProbe checks whether the event service needs to be restarted
+  livenessProbe:
+    # scheme to be used by the `readinessProbe`
+    scheme: "HTTP"
+  # readinessProbe checks whether the event service can receive traffic
+  readinessProbe:
+    # scheme to be used by the `readinessProbe`
+    scheme: "HTTP"
 
 # app (custom action server) specific settings
 app:
@@ -400,8 +420,14 @@ app:
     # annotations for the service
     annotations: {}
 
-  # scheme to be used by the `readinessProbe` and the `livenessProbe`
-  probeScheme: "HTTP"
+  # livenessProbe checks whether app needs to be restarted
+  livenessProbe:
+    # scheme to be used by the `readinessProbe`
+    scheme: "HTTP"
+  # readinessProbe checks whether app can receive traffic
+  readinessProbe:
+    # scheme to be used by the `readinessProbe`
+    scheme: "HTTP"
 
 # nginx specific settings
 nginx:
@@ -505,8 +531,14 @@ duckling:
     # annotations for the service
     annotations: {}
 
-  # scheme to be used by the `readinessProbe` and the `livenessProbe`
-  probeScheme: "HTTP"
+  # livenessProbe checks whether duckling needs to be restarted
+  livenessProbe:
+    # scheme to be used by the `readinessProbe`
+    scheme: "HTTP"
+  # readinessProbe checks whether duckling can receive traffic
+  readinessProbe:
+    # scheme to be used by the `readinessProbe`
+    scheme: "HTTP"
 
 # rasaSecret object which supplies passwords, tokens, etc. See
 # https://rasa.com/docs/rasa-x/openshift-kubernetes/#providing-access-credentials-using-an-external-secret

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -51,6 +51,8 @@ rasax:
     existingClaim: ""
   # initialProbeDelay for the `readinessProbe` and the `livenessProbe`
   initialProbeDelay: 10
+  # scheme to be used by the `readinessProbe` and the `livenessProbe`
+  probeScheme: "HTTP"
   # resources which Rasa X is required / allowed to use
   resources: {}
   # extraEnvs are environment variables which can be added to the Rasa X deployment
@@ -127,6 +129,8 @@ rasa:
   jaegerSidecar: "false"
   # initialProbeDelay for the `readinessProbe` and the `livenessProbe`
   initialProbeDelay: 10
+  # scheme to be used by the `readinessProbe` and the `livenessProbe`
+  probeScheme: "HTTP"
   # useLoginDatabase will use the Rasa X database to log in and create the database
   # for the tracker store. If `false` the tracker store database must have been created
   # previously.
@@ -326,6 +330,9 @@ eventService:
   # https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server
   automountServiceAccountToken: false
 
+  # scheme to be used by the `readinessProbe` and the `livenessProbe`
+  probeScheme: "HTTP"
+
 # app (custom action server) specific settings
 app:
   # override the default command to run in the container
@@ -421,6 +428,8 @@ nginx:
     externalIPs: []
   # initialProbeDelay for the `readinessProbe` and the `livenessProbe`
   initialProbeDelay: 10
+  # scheme to be used by the `readinessProbe` and the `livenessProbe`
+  probeScheme: "HTTP"
 
   # tolerations can be used to control the pod to node assignment
   # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
@@ -491,6 +500,9 @@ duckling:
   service:
     # annotations for the service
     annotations: {}
+
+  # scheme to be used by the `readinessProbe` and the `livenessProbe`
+  probeScheme: "HTTP"
 
 # rasaSecret object which supplies passwords, tokens, etc. See
 # https://rasa.com/docs/rasa-x/openshift-kubernetes/#providing-access-credentials-using-an-external-secret

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -129,7 +129,7 @@ rasa:
   jaegerSidecar: "false"
   # initialProbeDelay for the `readinessProbe` and the `livenessProbe`
   initialProbeDelay: 10
-  # scheme to be used by the `readinessProbe` and the `livenessProbe`
+  # scheme to be used by the `livenessProbe`
   probeScheme: "HTTP"
   # useLoginDatabase will use the Rasa X database to log in and create the database
   # for the tracker store. If `false` the tracker store database must have been created

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -280,6 +280,9 @@ dbMigrationService:
     # annotations for the service
     annotations: {}
 
+  # scheme to be used by the `readinessProbe` and the `livenessProbe`
+  probeScheme: "HTTP"
+
 # event-service specific settings
 eventService:
   # override the default command to run in the container
@@ -397,6 +400,9 @@ app:
     # annotations for the service
     annotations: {}
 
+  # scheme to be used by the `readinessProbe` and the `livenessProbe`
+  probeScheme: "HTTP"
+
 # nginx specific settings
 nginx:
   # enabled should be `true` if you want to use nginx
@@ -428,8 +434,6 @@ nginx:
     externalIPs: []
   # initialProbeDelay for the `readinessProbe` and the `livenessProbe`
   initialProbeDelay: 10
-  # scheme to be used by the `readinessProbe` and the `livenessProbe`
-  probeScheme: "HTTP"
 
   # tolerations can be used to control the pod to node assignment
   # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/


### PR DESCRIPTION
Starting pods on https will make them fail their liveness probes; make this configurable via values.