### PR TITLE
make scheme configurable, include full service DNS name

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "1.7.6"
+version: "1.7.7"
 appVersion: "0.33.0"
 
 name: rasa-x

--- a/charts/rasa-x/templates/nginx-deployment.yaml
+++ b/charts/rasa-x/templates/nginx-deployment.yaml
@@ -60,11 +60,11 @@ spec:
           initialDelaySeconds: {{ .Values.nginx.initialProbeDelay }}
         env:
         - name: "RASA_X_HOST"
-          value: "{{ include "rasa-x.host" . }}:{{ .Values.rasax.port }}"
+          value: "{{ include "rasa-x.host" . }}.{{ .Release.Namespace }}.svc:{{ .Values.rasax.port }}"
         - name: "RASA_PRODUCTION_HOST"
-          value: "{{ include "rasa-x.fullname" . }}-{{ .Values.rasa.versions.rasaProduction.serviceName }}:{{ .Values.rasa.port }}"
+          value: "{{ include "rasa-x.fullname" . }}-{{ .Values.rasa.versions.rasaProduction.serviceName }}.{{ .Release.Namespace }}.svc:{{ .Values.rasa.port }}"
         - name: "CUSTOM_ACTION_HOST"
-          value: "{{ include "rasa-x.fullname" . }}-app:{{ template "rasa-x.custom-actions.port" . }}"
+          value: "{{ include "rasa-x.fullname" . }}-app.{{ .Release.Namespace }}.svc:{{ template "rasa-x.custom-actions.port" . }}"
         volumeMounts:
 {{- if .Values.nginx.extraVolumeMounts }}
 {{ toYaml .Values.nginx.extraVolumeMounts | indent 8 }}

--- a/charts/rasa-x/templates/rasa-config-files-configmap.yaml
+++ b/charts/rasa-x/templates/rasa-config-files-configmap.yaml
@@ -7,7 +7,7 @@ metadata:
 data:
   rasa-credentials: |
     rasa:
-      url: {{  .Values.rasax.scheme }}://{{ include "rasa-x.host" . }}.{{ .Release.Namespace }}.svc:{{ .Values.rasax.port }}/api
+      url: {{ .Values.rasax.scheme }}://{{ include "rasa-x.host" . }}.{{ .Release.Namespace }}.svc:{{ .Values.rasax.port }}/api
     {{- with .Values.rasa.additionalChannelCredentials }}
     {{ toYaml . | nindent 4 }}
     {{- end }}
@@ -45,7 +45,7 @@ data:
       {{- end }}
       {{- end }}
     action_endpoint:
-      url: "{{  .Values.app.scheme }}://{{ include "rasa-x.fullname" . }}-app.{{ .Release.Namespace }}.svc:{{ template "rasa-x.custom-actions.port" . }}{{ .Values.app.endpoints.actionEndpointUrl }}"
+      url: "{{ .Values.app.scheme }}://{{ include "rasa-x.fullname" . }}-app.{{ .Release.Namespace }}.svc:{{ template "rasa-x.custom-actions.port" . }}{{ .Values.app.endpoints.actionEndpointUrl }}"
       token:  ""
     {{- if $.Values.redis.install }}
     lock_store:

--- a/charts/rasa-x/templates/rasa-config-files-configmap.yaml
+++ b/charts/rasa-x/templates/rasa-config-files-configmap.yaml
@@ -7,7 +7,7 @@ metadata:
 data:
   rasa-credentials: |
     rasa:
-      url: {{ default "HTTP" .Values.rasax.scheme }}://{{ include "rasa-x.host" . }}.{{ .Release.Namespace }}.svc:{{ .Values.rasax.port }}/api
+      url: {{  .Values.rasax.scheme }}://{{ include "rasa-x.host" . }}.{{ .Release.Namespace }}.svc:{{ .Values.rasax.port }}/api
     {{- with .Values.rasa.additionalChannelCredentials }}
     {{ toYaml . | nindent 4 }}
     {{- end }}
@@ -45,7 +45,7 @@ data:
       {{- end }}
       {{- end }}
     action_endpoint:
-      url: "{{ default "HTTP" .Values.app.scheme }}://{{ include "rasa-x.fullname" . }}-app.{{ .Release.Namespace }}.svc:{{ template "rasa-x.custom-actions.port" . }}{{ .Values.app.endpoints.actionEndpointUrl }}"
+      url: "{{  .Values.app.scheme }}://{{ include "rasa-x.fullname" . }}-app.{{ .Release.Namespace }}.svc:{{ template "rasa-x.custom-actions.port" . }}{{ .Values.app.endpoints.actionEndpointUrl }}"
       token:  ""
     {{- if $.Values.redis.install }}
     lock_store:

--- a/charts/rasa-x/templates/rasa-config-files-configmap.yaml
+++ b/charts/rasa-x/templates/rasa-config-files-configmap.yaml
@@ -7,7 +7,7 @@ metadata:
 data:
   rasa-credentials: |
     rasa:
-      url: http://{{ include "rasa-x.host" . }}:{{ .Values.rasax.port }}/api
+      url: {{ default "HTTP" .Values.rasax.scheme }}://{{ include "rasa-x.host" . }}.{{ .Release.Namespace }}.svc:{{ .Values.rasax.port }}/api
     {{- with .Values.rasa.additionalChannelCredentials }}
     {{ toYaml . | nindent 4 }}
     {{- end }}
@@ -45,7 +45,7 @@ data:
       {{- end }}
       {{- end }}
     action_endpoint:
-      url: "http://{{ include "rasa-x.fullname" . }}-app:{{ template "rasa-x.custom-actions.port" . }}{{ .Values.app.endpoints.actionEndpointUrl }}"
+      url: "{{ default "HTTP" .Values.app.scheme }}://{{ include "rasa-x.fullname" . }}-app.{{ .Release.Namespace }}.svc:{{ template "rasa-x.custom-actions.port" . }}{{ .Values.app.endpoints.actionEndpointUrl }}"
       token:  ""
     {{- if $.Values.redis.install }}
     lock_store:

--- a/charts/rasa-x/templates/rasa-deployments.yaml
+++ b/charts/rasa-x/templates/rasa-deployments.yaml
@@ -67,7 +67,7 @@ spec:
         - --no-prompt
         - --production
         - --config-endpoint
-        - {{ default "HTTP" $.Values.rasax.scheme }}://{{ include "rasa-x.fullname" $ }}-rasa-x.{{ $.Release.Namespace }}.svc:{{ default 5002 $.Values.rasax.port }}/api/config?token=$(RASA_X_TOKEN)
+        - {{  $.Values.rasax.scheme }}://{{ include "rasa-x.fullname" $ }}-rasa-x.{{ $.Release.Namespace }}.svc:{{ default 5002 $.Values.rasax.port }}/api/config?token=$(RASA_X_TOKEN)
         - --port
         - "{{ $.Values.rasa.port }}"
         - --jwt-method
@@ -135,9 +135,9 @@ spec:
         - name: "RASA_ENVIRONMENT"
           value: "{{ .rasaEnvironment }}"
         - name: "RASA_MODEL_SERVER"
-          value: {{ default "HTTP" $.Values.rasax.scheme }}://{{ include "rasa-x.host" $ }}.{{ $.Release.Namespace }}.svc:{{ $.Values.rasax.port }}/api/projects/default/models/tags/{{ .modelTag }}
+          value: {{ $.Values.rasax.scheme }}://{{ include "rasa-x.host" $ }}.{{ $.Release.Namespace }}.svc:{{ $.Values.rasax.port }}/api/projects/default/models/tags/{{ .modelTag }}
         - name: "RASA_DUCKLING_HTTP_URL"
-          value: {{ default "HTTP" $.Values.duckling.scheme }}://{{ include "duckling.host" $ }}.{{ $.Release.Namespace }}.svc:{{ $.Values.duckling.port }}
+          value: {{ $.Values.duckling.scheme }}://{{ include "duckling.host" $ }}.{{ $.Release.Namespace }}.svc:{{ $.Values.duckling.port }}
         {{- include "rasa.extra.envs" $ | nindent 8 }}
         volumeMounts:
         # Mount the temporary directory for the Rasa global configuration

--- a/charts/rasa-x/templates/rasa-deployments.yaml
+++ b/charts/rasa-x/templates/rasa-deployments.yaml
@@ -67,7 +67,7 @@ spec:
         - --no-prompt
         - --production
         - --config-endpoint
-        - {{  $.Values.rasax.scheme }}://{{ include "rasa-x.fullname" $ }}-rasa-x.{{ $.Release.Namespace }}.svc:{{ default 5002 $.Values.rasax.port }}/api/config?token=$(RASA_X_TOKEN)
+        - {{ $.Values.rasax.scheme }}://{{ include "rasa-x.fullname" $ }}-rasa-x.{{ $.Release.Namespace }}.svc:{{ default 5002 $.Values.rasax.port }}/api/config?token=$(RASA_X_TOKEN)
         - --port
         - "{{ $.Values.rasa.port }}"
         - --jwt-method

--- a/charts/rasa-x/templates/rasa-deployments.yaml
+++ b/charts/rasa-x/templates/rasa-deployments.yaml
@@ -67,7 +67,7 @@ spec:
         - --no-prompt
         - --production
         - --config-endpoint
-        - "http://{{ include "rasa-x.fullname" $ }}-rasa-x:{{ default 5002 $.Values.rasax.port }}/api/config?token=$(RASA_X_TOKEN)"
+        - {{ default "HTTP" $.Values.rasax.scheme }}://{{ include "rasa-x.fullname" $ }}-rasa-x.{{ $.Release.Namespace }}.svc:{{ default 5002 $.Values.rasax.port }}/api/config?token=$(RASA_X_TOKEN)
         - --port
         - "{{ $.Values.rasa.port }}"
         - --jwt-method
@@ -135,9 +135,9 @@ spec:
         - name: "RASA_ENVIRONMENT"
           value: "{{ .rasaEnvironment }}"
         - name: "RASA_MODEL_SERVER"
-          value: "http://{{ include "rasa-x.host" $ }}:{{ $.Values.rasax.port }}/api/projects/default/models/tags/{{ .modelTag }}"
+          value: {{ default "HTTP" $.Values.rasax.scheme }}://{{ include "rasa-x.host" $ }}.{{ $.Release.Namespace }}.svc:{{ $.Values.rasax.port }}/api/projects/default/models/tags/{{ .modelTag }}
         - name: "RASA_DUCKLING_HTTP_URL"
-          value: "http://{{ include "duckling.host" $ }}:{{ $.Values.duckling.port }}"
+          value: {{ default "HTTP" $.Values.duckling.scheme }}://{{ include "duckling.host" $ }}.{{ $.Release.Namespace }}.svc:{{ $.Values.duckling.port }}
         {{- include "rasa.extra.envs" $ | nindent 8 }}
         volumeMounts:
         # Mount the temporary directory for the Rasa global configuration

--- a/charts/rasa-x/templates/rasa-x-config-files-configmap.yaml
+++ b/charts/rasa-x/templates/rasa-x-config-files-configmap.yaml
@@ -8,8 +8,8 @@ data:
   environments: |
     rasa:
       production:
-        url: "http://{{ include "rasa-x.fullname" . }}-{{ .Values.rasa.versions.rasaProduction.serviceName }}:{{ .Values.rasa.port }}"
+        url: "{{ default "HTTP" .Values.rasa.scheme }}://{{ include "rasa-x.fullname" . }}-{{ .Values.rasa.versions.rasaProduction.serviceName }}:{{ .Values.rasa.port }}"
         token: ${RASA_TOKEN}
       worker:
-        url: "http://{{ include "rasa-x.fullname" . }}-{{ .Values.rasa.versions.rasaWorker.serviceName }}:{{ .Values.rasa.port }}"
+        url: "{{ default "HTTP" .Values.rasa.scheme }}://{{ include "rasa-x.fullname" . }}-{{ .Values.rasa.versions.rasaWorker.serviceName }}:{{ .Values.rasa.port }}"
         token: ${RASA_TOKEN}

--- a/charts/rasa-x/templates/rasa-x-config-files-configmap.yaml
+++ b/charts/rasa-x/templates/rasa-x-config-files-configmap.yaml
@@ -8,8 +8,8 @@ data:
   environments: |
     rasa:
       production:
-        url: "{{ default "HTTP" .Values.rasa.scheme }}://{{ include "rasa-x.fullname" . }}-{{ .Values.rasa.versions.rasaProduction.serviceName }}.{{ .Release.Namespace }}.svc:{{ .Values.rasa.port }}"
+        url: "{{ .Values.rasa.scheme }}://{{ include "rasa-x.fullname" . }}-{{ .Values.rasa.versions.rasaProduction.serviceName }}.{{ .Release.Namespace }}.svc:{{ .Values.rasa.port }}"
         token: ${RASA_TOKEN}
       worker:
-        url: "{{ default "HTTP" .Values.rasa.scheme }}://{{ include "rasa-x.fullname" . }}-{{ .Values.rasa.versions.rasaWorker.serviceName }}:{{ .Values.rasa.port }}"
+        url: "{{ .Values.rasa.scheme }}://{{ include "rasa-x.fullname" . }}-{{ .Values.rasa.versions.rasaWorker.serviceName }}:{{ .Values.rasa.port }}"
         token: ${RASA_TOKEN}

--- a/charts/rasa-x/templates/rasa-x-config-files-configmap.yaml
+++ b/charts/rasa-x/templates/rasa-x-config-files-configmap.yaml
@@ -8,7 +8,7 @@ data:
   environments: |
     rasa:
       production:
-        url: "{{ default "HTTP" .Values.rasa.scheme }}://{{ include "rasa-x.fullname" . }}-{{ .Values.rasa.versions.rasaProduction.serviceName }}:{{ .Values.rasa.port }}"
+        url: "{{ default "HTTP" .Values.rasa.scheme }}://{{ include "rasa-x.fullname" . }}-{{ .Values.rasa.versions.rasaProduction.serviceName }}.{{ .Release.Namespace }}.svc:{{ .Values.rasa.port }}"
         token: ${RASA_TOKEN}
       worker:
         url: "{{ default "HTTP" .Values.rasa.scheme }}://{{ include "rasa-x.fullname" . }}-{{ .Values.rasa.versions.rasaWorker.serviceName }}:{{ .Values.rasa.port }}"

--- a/charts/rasa-x/templates/rasa-x-deployment.yaml
+++ b/charts/rasa-x/templates/rasa-x-deployment.yaml
@@ -82,7 +82,7 @@ spec:
         - name: "LOCAL_MODE" # This variable doesn't do anything anymore in Rasa X 0.28 and later
           value: "false"
         - name: "RASA_X_HOST"
-          value: {{ default "HTTP" .Values.rasax.scheme }}://{{ include "rasa-x.host" . }}.{{ .Release.Namespace }}.svc:{{ .Values.rasax.port }}
+          value: {{ .Values.rasax.scheme }}://{{ include "rasa-x.host" . }}.{{ .Release.Namespace }}.svc:{{ .Values.rasax.port }}
         - name: "RASA_MODEL_DIR"
           value: "/app/models"
         - name: "RUN_EVENT_CONSUMER_AS_SEPARATE_SERVICE"

--- a/charts/rasa-x/templates/rasa-x-deployment.yaml
+++ b/charts/rasa-x/templates/rasa-x-deployment.yaml
@@ -82,7 +82,7 @@ spec:
         - name: "LOCAL_MODE" # This variable doesn't do anything anymore in Rasa X 0.28 and later
           value: "false"
         - name: "RASA_X_HOST"
-          value: "http://{{ include "rasa-x.host" . }}:{{ .Values.rasax.port }}"
+          value: {{ default "HTTP" .Values.rasax.scheme }}://{{ include "rasa-x.host" . }}.{{ .Release.Namespace }}.svc:{{ .Values.rasax.port }}
         - name: "RASA_MODEL_DIR"
           value: "/app/models"
         - name: "RUN_EVENT_CONSUMER_AS_SEPARATE_SERVICE"

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -14,7 +14,7 @@ rasax:
   tag: ""
   # port on which Rasa X runs
   port: 5002
-  # scheme
+  # scheme by which Rasa X is accessible
   scheme: http
   # passwordSalt Rasa X uses to salt the user passwords
   passwordSalt: "passwordSalt"
@@ -116,7 +116,7 @@ rasa:
   tag: ""
   # port on which Rasa runs
   port: 5005
-  # scheme
+  # scheme by which Rasa services are accessible
   scheme: http
   # token Rasa accepts as authentication token from other Rasa services
   token: "rasaToken"
@@ -374,6 +374,8 @@ app:
   replicaCount: 1
   # port on which the custom action server runs
   port: 5055
+  # scheme by which custom action server is accessible
+  scheme: http
   # resources which app is required / allowed to use
   resources: {}
   # Jaeger Sidecar
@@ -510,7 +512,7 @@ duckling:
   replicaCount: 1
   # port on which duckling should run
   port: 8000
-  # scheme
+  # scheme by which duckling is accessible
   scheme: http
 
   # tolerations can be used to control the pod to node assignment

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -14,6 +14,8 @@ rasax:
   tag: ""
   # port on which Rasa X runs
   port: 5002
+  # scheme
+  scheme: http
   # passwordSalt Rasa X uses to salt the user passwords
   passwordSalt: "passwordSalt"
   # token Rasa X accepts as authentication token from other Rasa services
@@ -114,6 +116,8 @@ rasa:
   tag: ""
   # port on which Rasa runs
   port: 5005
+  # scheme
+  scheme: https
   # token Rasa accepts as authentication token from other Rasa services
   token: "rasaToken"
   # rabbitQueue it should use to dispatch events to Rasa X
@@ -506,6 +510,8 @@ duckling:
   replicaCount: 1
   # port on which duckling should run
   port: 8000
+  # scheme
+  scheme: http
 
   # tolerations can be used to control the pod to node assignment
   # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -117,7 +117,7 @@ rasa:
   # port on which Rasa runs
   port: 5005
   # scheme
-  scheme: https
+  scheme: http
   # token Rasa accepts as authentication token from other Rasa services
   token: "rasaToken"
   # rabbitQueue it should use to dispatch events to Rasa X


### PR DESCRIPTION
 - make scheme (http/s) configurable for rasa, rasa-x and duckling
-  include full service DNS name in host paths 

Problem trying to solve: Providing https urls for model server/config endpoint etc. 
Why we can't just set the env var in values.yml: the default certs are valid only for the service DNS name. The full service DNS name needs {{ .Release.Namespace }} to be resolved, which isn't accessible from values.yml.

