### PR TITLE
Separate annotations for rasa services and use correct url for rasa-worker

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "1.7.9"
+version: "1.7.10"
 
 appVersion: "0.33.0"
 

--- a/charts/rasa-x/templates/rasa-services.yaml
+++ b/charts/rasa-x/templates/rasa-services.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{ include "rasa-x.labels" $ | nindent 4 }}
     app.kubernetes.io/component: {{ .serviceName }}
-{{- with $.Values.rasa.service.annotations }}
+{{- with .annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
 {{- end }}

--- a/charts/rasa-x/templates/rasa-services.yaml
+++ b/charts/rasa-x/templates/rasa-services.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{ include "rasa-x.labels" $ | nindent 4 }}
     app.kubernetes.io/component: {{ .serviceName }}
-{{- with .annotations }}
+{{- with .service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
 {{- end }}

--- a/charts/rasa-x/templates/rasa-x-config-files-configmap.yaml
+++ b/charts/rasa-x/templates/rasa-x-config-files-configmap.yaml
@@ -11,5 +11,5 @@ data:
         url: "{{ .Values.rasa.scheme }}://{{ include "rasa-x.fullname" . }}-{{ .Values.rasa.versions.rasaProduction.serviceName }}.{{ .Release.Namespace }}.svc:{{ .Values.rasa.port }}"
         token: ${RASA_TOKEN}
       worker:
-        url: "{{ .Values.rasa.scheme }}://{{ include "rasa-x.fullname" . }}-{{ .Values.rasa.versions.rasaWorker.serviceName }}:{{ .Values.rasa.port }}"
+        url: "{{ .Values.rasa.scheme }}://{{ include "rasa-x.fullname" . }}-{{ .Values.rasa.versions.rasaWorker.serviceName }}.{{ .Release.Namespace }}.svc:{{ .Values.rasa.port }}"
         token: ${RASA_TOKEN}

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -179,11 +179,6 @@ rasa:
   # https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server
   automountServiceAccountToken: false
 
-  # service specifies settings for exposing rasa to other services
-  service:
-    # annotations for the service
-    annotations: {}
-
   # versions of the Rasa container which are running
   versions:
     # rasaProduction is the container which serves the production environment
@@ -192,6 +187,10 @@ rasa:
       replicaCount: 1
       # serviceName with which the Rasa production deployment is exposed to other containers
       serviceName: "rasa-production"
+      # service specifies settings for exposing rasa production to other services
+      service:
+        # annotations for the service
+        annotations: {}
       # modelTag of the model Rasa should pull from the the model server
       modelTag: "production"
       # trackerDatabase it should use to to store conversation trackers
@@ -215,6 +214,10 @@ rasa:
       replicaCount: 1
       # serviceName with which the Rasa worker deployment is exposed to other containers
       serviceName: "rasa-worker"
+      # service specifies settings for exposing rasa worker to other services
+      service:
+        # annotations for the service
+        annotations: {}
       # modelTag of the model Rasa should pull from the the model server
       modelTag: "production"
       # trackerDatabase it should use to to store conversation trackers


### PR DESCRIPTION
- make it possible to annotate services separately, as they need their own ssl certificates. 
- correct the rasa-worker URL so that the ssl cert for it is valid.