### PR TITLE
Add changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
     - master
+    tags:
+    - '**'
+
+env:
+  IS_TAG_BUILD: ${{ startsWith(github.event.ref, 'refs/tags') }
 
 jobs:
   release:
@@ -30,3 +35,19 @@ jobs:
       uses: helm/chart-releaser-action@v1.1.0
       env:
         CR_TOKEN: "${{ secrets.CR_TOKEN }}"
+
+    - name: Publish Release Notes 🗞
+      if: env.IS_TAG_BUILD
+      env:
+        GITHUB_TAG: ${{ github.ref }}
+        GITHUB_REPO_SLUG: ${{ github.repository }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TAG=${GITHUB_TAG/refs\/tags\//}
+        sudo apt-get update
+        sudo apt-get -y install pandoc
+        pip install -U github3.py pep440_version_utils
+        python3 ${GITHUB_WORKSPACE}/scripts/publish_gh_release_notes.py
+
+    # TODO: clean changlog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Configure Git
       run: |
@@ -27,6 +27,6 @@ jobs:
         helm repo add bitnami https://charts.bitnami.com/bitnami
 
     - name: Run chart-releaser
-      uses: helm/chart-releaser-action@v1.0.0-rc.2
+      uses: helm/chart-releaser-action@v1.1.0
       env:
         CR_TOKEN: "${{ secrets.CR_TOKEN }}"

--- a/changelog/.gitignore
+++ b/changelog/.gitignore
@@ -1,0 +1,2 @@
+# Except this file
+!.gitignore

--- a/changelog/82.improvement.md
+++ b/changelog/82.improvement.md
@@ -1,0 +1,1 @@
+Added a test file.

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,0 +1,37 @@
+This directory contains "newsfragments" which are short files that contain a small 
+**Markdown**-formatted text that will be added to the next `CHANGELOG`.
+
+The `CHANGELOG` will be read by **users**, so this description should be aimed 
+to Rasa OSS users instead of describing internal changes which are only relevant 
+to the developers.
+
+Make sure to use full sentences in the **past or present tense** and use 
+punctuation, examples:
+
+    Slots will be correctly interpolated if there are lists in custom response templates.
+
+    Previously this resulted in no interpolation.
+
+Each file should be named like `<ISSUE>.<TYPE>.md`, where
+`<ISSUE>` is an issue / PR number, and `<TYPE>` is one of:
+
+* `feature`: new user facing features, like new command-line options and new behavior.
+* `improvement`: improvement of existing functionality, usually without requiring user intervention.
+* `bugfix`: fixes a reported bug.
+* `doc`: documentation improvement, like rewording an entire session or adding missing docs.
+* `removal`: feature deprecation or feature removal.
+* `misc`: fixing a small typo or internal change, will not be included in the changelog.
+
+So for example: `123.feature.md`, `456.bugfix.md`.
+
+If your PR fixes an issue, use that number here. If there is no issue,
+then after you submit the PR and get the PR number you can add a
+changelog using that instead.
+
+If you are not sure what issue type to use, don't hesitate to ask in your PR.
+
+`towncrier` preserves multiple paragraphs and formatting (code blocks, lists, 
+and so on), but for entries other than `features` it is usually better to stick 
+to a single paragraph to keep it concise. You can install `towncrier` and then 
+run `towncrier --draft` if you want to get a preview of how your change will look 
+in the final release notes.

--- a/changelog/_template.md.jinja2
+++ b/changelog/_template.md.jinja2
@@ -1,0 +1,10 @@
+{# Based on https://github.com/hawkowl/towncrier/blob/master/src/towncrier/templates/default.rst #}
+{% for section in sections %}{% if section %}{{section}}{% endif %}{% if sections[section] %}{% for category, val in definitions.items() if category in sections[section] %}
+
+{{ "### " + definitions[category]['name'] }}
+{% if definitions[category]['showcontent'] %}{% for text, values in sections[section][category]|dictsort(by='value') %}{% set issue_joiner = joiner(', ') %}- {% for value in values|sort %}{{ issue_joiner() }}{{ value }}{% endfor %}: {{ text }}
+{% endfor %}{% else %}- {{ sections[section][category]['']|sort|join(', ') }}{% endif %}{% if sections[section][category]|length == 0 %} No significant changes.
+
+{% else %}{% endif %}{% endfor %}{% else %} No significant changes.
+
+{% endif %}{% endfor %}

--- a/scripts/publish_gh_release_notes.py
+++ b/scripts/publish_gh_release_notes.py
@@ -1,0 +1,102 @@
+"""
+Script used to publish GitHub release notes extracted from CHANGELOG.mdx.
+This script is executed by GitHub after a new release was successfully built.
+
+Uses the following environment variables:
+* GITHUB_TAG: the name of the tag of the current commit.
+* GITHUB_TOKEN: a personal access token with 'repo' permissions.
+
+The script also requires ``pandoc`` to be previously installed in the system.
+Requires Python3.6+.
+
+Based on code from pytest.
+https://github.com/pytest-dev/pytest/blob/master/scripts/publish_gh_release_notes.py
+Copyright Holger Krekel and others, 2004-2019.
+
+Distributed under the terms of the MIT license, pytest is free and open source software.
+"""
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Text
+
+# if this needs any more dependencies, they need to be installed on github deploy stage
+import github3
+from pep440_version_utils import Version
+
+def create_github_release(slug: Text, token: Text, tag_name: Text, body: Text):
+    """Create a github release."""
+
+    github = github3.login(token=token)
+    owner, repo = slug.split("/")
+    repo = github.repository(owner, repo)
+    return repo.create_release(tag_name=tag_name, body=body)
+
+
+def parse_changelog(tag_name: Text) -> Text:
+    """Read the changelog and extract the most recently release entry."""
+
+    p = Path(__file__).parent.parent / "CHANGELOG.mdx"
+    changelog_lines = p.read_text(encoding="UTF-8").splitlines()
+
+    title_regex = re.compile(r"##\s*\[(\d+\.\d+\.\d+)(\S*)\]\s*-\s*\d{4}-\d{2}-\d{2}")
+    consuming_version = False
+    version_lines = []
+    for line in changelog_lines:
+        m = title_regex.match(line)
+        if m:
+            # found the version we want: start to consume lines
+            # until we find the next version title
+            if m.group(1) == tag_name:
+                consuming_version = True
+            # found a new version title while parsing the version we want: break out
+            elif consuming_version:
+                break
+        if consuming_version:
+            version_lines.append(line)
+
+    # drop the first lines (version headline, not needed for GH)
+    return "\n".join(version_lines[2:]).strip()
+
+
+def main():
+    tag_name = os.environ.get("GITHUB_TAG")
+    if not tag_name:
+        print("environment variable GITHUB_TAG not set", file=sys.stderr)
+        return 1
+
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        print("GITHUB_TOKEN not set", file=sys.stderr)
+        return 1
+
+    slug = os.environ.get("GITHUB_REPO_SLUG")
+    if not slug:
+        print("GITHUB_REPO_SLUG not set", file=sys.stderr)
+        return 1
+
+    version = Version(tag_name)
+    if version.pre:
+        md_body = "_Pre-release version_"
+    else:
+        md_body = parse_changelog(tag_name)
+
+    if not md_body:
+        print("Failed to extract changelog entries for version from changelog.")
+        return 2
+
+    if not create_github_release(slug, token, tag_name, md_body):
+        print("Could not publish release notes:", file=sys.stderr)
+        print(md_body, file=sys.stderr)
+        return 5
+
+    print()
+    print(f"Release notes for {tag_name} published successfully:")
+    print(f"https://github.com/{slug}/releases/tag/{tag_name}")
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
- Copy README, template, and gitignore from Rasa SDK
- Copy `publish_gh_release.py` script from Rasa SDK
- Upgrade GH `checkout` and `chat-releaser` version
- Adapt `publish_gh_release.py` script to update the latest release instead of creating a new one

We use [chart-releaser-action](https://github.com/helm/chart-releaser-action) to push the release of new version. It will automatically push a release without changelogs, which is bad.  

- Create new jobs in `release.yml` to collect change logs