### PR TITLE
Fix ingress spec for nginx container

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "1.7.16"
+version: "1.7.17"
 
 appVersion: "0.35.0"
 

--- a/charts/rasa-x/templates/ingress.yaml
+++ b/charts/rasa-x/templates/ingress.yaml
@@ -1,9 +1,9 @@
 {{- if and .Values.ingress.enabled .Values.nginx.enabled -}}
 {{- $fullName := include "rasa-x.fullname" . -}}
 {{- $svcPort := .Values.nginx.service.port -}}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19" .Capabilities.KubeVersion.Version -}}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- else if semverCompare ">=1.14" .Capabilities.KubeVersion.Version -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -29,7 +29,7 @@ spec:
   {{- end }}
 {{- end }}
   rules:
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19" .Capabilities.KubeVersion.Version -}}
   {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}
       http:
@@ -40,10 +40,10 @@ spec:
             backend:
               service:
                 name: {{ $fullName }}-nginx
-                port: 
+                port:
                   number: {{ $svcPort }}
         {{- end }}
-  {{- end }}          
+  {{- end }}
 {{- else -}}
   {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}
@@ -52,9 +52,9 @@ spec:
         {{- range .paths }}
           - path: {{ . }}
             backend:
-              service.name: {{ $fullName }}-nginx
-              service.port: {{ $svcPort }}
+              serviceName: {{ $fullName }}-nginx
+              servicePort: {{ $svcPort }}
         {{- end }}
-  {{- end }}      
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/rasa-x/templates/rasa-open-source-ingress.yaml
+++ b/charts/rasa-x/templates/rasa-open-source-ingress.yaml
@@ -1,8 +1,8 @@
 {{- if and .Values.ingress.enabled (not .Values.nginx.enabled) -}}
 {{- $fullName := include "rasa-x.fullname" . -}}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19" .Capabilities.KubeVersion.Version -}}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- else if semverCompare ">=1.14" .Capabilities.KubeVersion.Version -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -32,8 +32,8 @@ spec:
   {{- end }}
 {{- end }}
   rules:
-  
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+
+{{- if semverCompare ">=1.19" .Capabilities.KubeVersion.Version -}}
     {{- range .Values.ingress.hosts }}
   - host: {{ .host | quote }}
     http:
@@ -41,25 +41,25 @@ spec:
       - backend:
           service:
             name: {{ $fullName }}-{{ $.Values.rasa.versions.rasaProduction.serviceName }}
-            port: 
+            port:
               number: {{ $.Values.rasa.port }}
         path: /core/(.*)
         pathType: Prefix
       - backend:
           service:
             name: {{ $fullName }}-{{ $.Values.rasa.versions.rasaProduction.serviceName }}
-            port: 
+            port:
               number: {{ $.Values.rasa.port }}
         path: /webhooks/
         pathType: Prefix
       - backend:
           service:
             name: {{ $fullName }}-{{ $.Values.rasa.versions.rasaProduction.serviceName }}
-            port: 
+            port:
               number: {{ $.Values.rasa.port }}
         path: /socket.io
         pathType: Prefix
-    {{- end }}    
+    {{- end }}
 {{- else -}}
     {{- range .Values.ingress.hosts }}
   - host: {{ .host | quote }}
@@ -77,6 +77,6 @@ spec:
           serviceName: {{ $fullName }}-{{ $.Values.rasa.versions.rasaProduction.serviceName }}
           servicePort: {{ $.Values.rasa.port }}
         path: /socket.io
-    {{- end }}    
-{{- end }}  
+    {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/rasa-x/templates/rasa-x-ingress.yaml
+++ b/charts/rasa-x/templates/rasa-x-ingress.yaml
@@ -1,9 +1,9 @@
 {{- if and .Values.ingress.enabled (not .Values.nginx.enabled) -}}
 {{- $fullName := include "rasa-x.fullname" . -}}
 {{- $rasaxHost := include "rasa-x.host" . -}}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19" .Capabilities.KubeVersion.Version -}}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- else if semverCompare ">=1.14" .Capabilities.KubeVersion.Version -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -44,7 +44,7 @@ spec:
   {{- end }}
 {{- end }}
   rules:
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19" .Capabilities.KubeVersion.Version -}}
   {{- range .Values.ingress.hosts }}
   - host: {{ .host | quote }}
     http:
@@ -52,11 +52,11 @@ spec:
       - backend:
           service:
             name: {{ $rasaxHost }}
-            port: 
+            port:
               number: {{ $.Values.rasax.port }}
         pathType: Prefix
         path: /
-  {{- end }}          
+  {{- end }}
 {{- else }}
   {{- range .Values.ingress.hosts }}
   - host: {{ .host | quote }}


### PR DESCRIPTION
- Remove deprecated `.Capabilities.KubeVersion.Version`
- Fix ingress spec for nginx container