### PR TITLE
Add "cache" section to the endpoints.yml

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "1.7.19"
+version: "1.7.20"
 
 appVersion: "0.35.0"
 

--- a/charts/rasa-x/templates/rasa-config-files-configmap.yaml
+++ b/charts/rasa-x/templates/rasa-config-files-configmap.yaml
@@ -56,6 +56,13 @@ data:
       port: {{ default 6379 .Values.redis.redisPort }}
       password: ${REDIS_PASSWORD}
       db: {{ default "1" .Values.rasa.lockStoreDatabase }}
+    cache:
+      type: "redis"
+      url: {{ template "rasa-x.redis.host" . }}
+      port: {{ default 6379 .Values.redis.redisPort }}
+      password: ${REDIS_PASSWORD}
+      db: {{ default "2" .Values.rasa.cacheDatabase }}
+      key_prefix: "rasax_cache"
     {{- end }}
     {{- with .Values.rasa.additionalEndpoints }}
     {{ toYaml . | nindent 4 }}

--- a/charts/rasa-x/templates/rasa-x-deployment.yaml
+++ b/charts/rasa-x/templates/rasa-x-deployment.yaml
@@ -96,6 +96,13 @@ spec:
               name: {{ template "rasa-x.rabbitmq.password.secret" . }}
               key: {{ template "rasa-x.rabbitmq.password.key" . }}
         {{- end }}
+        {{- if $.Values.redis.install }}
+        - name: "REDIS_PASSWORD"
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "rasa-x.redis.password.secret" $ }}
+              key: {{ template "rasa-x.redis.password.key" $ }}
+        {{- end }}
         - name: "PASSWORD_SALT"
           valueFrom:
             secretKeyRef:

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -150,6 +150,8 @@ rasa:
   useLoginDatabase: true
   # lockStoreDatabase is the database in redis which Rasa uses to store the conversation locks
   lockStoreDatabase: "1"
+  # cacheDatabase is the database in redis which Rasa X uses to store cached values
+  cacheDatabase: "2"
   # extraEnvs are environment variables which can be added to the Rasa deployment
   extraEnvs: []
     # example which sets env variables in each Rasa Open Source service from a separate k8s secret


### PR DESCRIPTION
As part of https://github.com/RasaHQ/rasa-x/pull/4401 we need to have a new "cache" section in the `endpoints.yml`.

- Add new section to the config map
- Pass `REDIS_PASSWORD` env variable to the rasa-x pods