### PR TITLE
redis password for event service

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "1.7.20"
+version: "1.7.21"
 
 appVersion: "0.35.0"
 

--- a/charts/rasa-x/templates/event-service-deployment.yaml
+++ b/charts/rasa-x/templates/event-service-deployment.yaml
@@ -82,6 +82,13 @@ spec:
               name: {{ template "rasa-x.rabbitmq.password.secret" . }}
               key: {{ template "rasa-x.rabbitmq.password.key" . }}
         {{ end }}
+        {{- if $.Values.redis.install }}
+        - name: "REDIS_PASSWORD"
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "rasa-x.redis.password.secret" $ }}
+              key: {{ template "rasa-x.redis.password.key" $ }}
+        {{- end }}
         - name: "RASA_X_USER_ANALYTICS"
           value: "0"
         - name: "LOCAL_MODE" # This variable doesn't do anything anymore in Rasa X 0.28 and later


### PR DESCRIPTION
Make the  REDIS_PASSWORD  env var available to the event service deployment, since https://github.com/RasaHQ/rasa-x-helm/pull/144/files introduces a section that requires the password, and the event service cannot read the endpoints file without it.. 