### PR TITLE
fix_update_rasa_x_version_workflow

### DIFF
--- a/.github/workflows/update_rasa_x_version.yml
+++ b/.github/workflows/update_rasa_x_version.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          
+
       - name: Get latest Rasa X minor 🏷
         run: |
           DOCKERHUB_TAGS_URL="https://registry.hub.docker.com/v2/repositories/rasa/rasa-x/tags?page_size=10000"
@@ -50,11 +50,10 @@ jobs:
 
       - name: Check if duplicated branch exists 🔍
         run: |
-          git fetch origin
+          BRANCH_NAME=$(git branch -a | grep -m 1 "bump-rasa-x-version-to-${LATEST_RASA_X_MINOR}" || echo "")
 
-          BRANCH_NAME=$(git branch -a | grep -q "bump-rasa-x-version-to-${LATEST_RASA_X_MINOR}")
-
-          if [[ ${BRANCH_NAME} ]]; then
+          # Set CREATE_UPDATE_PR to false if BRANCH_NAME is not empty ("")
+          if [[ ! -z ${BRANCH_NAME} ]]; then
             echo "Found related branch ${BRANCH_NAME}."
             echo "The newest version of Rasa X (${LATEST_RASA_X_MINOR}) has already been bumped."
             echo "CREATE_UPDATE_PR=false" >> $GITHUB_ENV

--- a/.github/workflows/update_rasa_x_version.yml
+++ b/.github/workflows/update_rasa_x_version.yml
@@ -19,7 +19,9 @@ jobs:
 
       - name: Checkout rasa-x-helm github repository 🕝
         uses: actions/checkout@v2
-
+        with:
+          fetch-depth: 0
+          
       - name: Get latest Rasa X minor 🏷
         run: |
           DOCKERHUB_TAGS_URL="https://registry.hub.docker.com/v2/repositories/rasa/rasa-x/tags?page_size=10000"
@@ -50,9 +52,9 @@ jobs:
         run: |
           git fetch origin
 
-          BRANCH_NAME=$(git branch | grep -m 1 "bump-rasa-x-version-to-${LATEST_RASA_X_MINOR}")
+          BRANCH_NAME=$(git branch -a | grep -q "bump-rasa-x-version-to-${LATEST_RASA_X_MINOR}")
 
-          if [[ ! -z ${BRANCH_NAME} ]]; then
+          if [[ ${BRANCH_NAME} ]]; then
             echo "Found related branch ${BRANCH_NAME}."
             echo "The newest version of Rasa X (${LATEST_RASA_X_MINOR}) has already been bumped."
             echo "CREATE_UPDATE_PR=false" >> $GITHUB_ENV


### PR DESCRIPTION
Previously, the step ` Check if duplicated branch exists 🔍` fails with `exit code 1`. This is caused by the line 
```
BRANCH_NAME=$(git branch | grep -m 1 "bump-rasa-x-version-to-${LATEST_RASA_X_MINOR}")
```
When there is no `bump-to-rasa-x-version-XXXX` branch found, `grep` will return `exit code 1`, instead of an emty string `""`.  Now it is fixed by adding `|| echo ""` in the end. 

The workflow runs [as expected without any error](https://github.com/RasaHQ/rasa-x-helm/actions/runs/610975341), and correctly created a [PR](https://github.com/RasaHQ/rasa-x-helm/pull/152) bumping Rasa X version to `0.37.0`. 