### PR TITLE
Clarify lack of support for redis clusters

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "1.8.1"
+version: "1.8.2"
 
 appVersion: "0.35.0"
 

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -676,7 +676,7 @@ redis:
   install: true
   # cluster settings for redis (Rasa does currently not support redis sentinels)
   cluster:
-    # enabled should be `true` in case a redis cluster should be set up and `false` for a single instance
+    # set up a single Redis instance, as `redis-py` does not support clusters (https://github.com/andymccurdy/redis-py#cluster-mode)
     enabled: false
   # redisPort: port which should be used to expose redis to the other components
   redisPort: 6379


### PR DESCRIPTION
Just a quick clarification that we don't support redis clusters because we use `redis-py` which does not support clusters: https://github.com/andymccurdy/redis-py#cluster-mode