### PR TITLE
make nginx liveness/readiness probe commands configurable

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "1.8.2"
+version: "1.8.3"
 
 appVersion: "0.38.0"
 

--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "1.8.3"
+version: "1.8.4"
 
 appVersion: "0.38.1"
 

--- a/charts/rasa-x/templates/nginx-deployment.yaml
+++ b/charts/rasa-x/templates/nginx-deployment.yaml
@@ -50,16 +50,26 @@ spec:
           protocol: "TCP"
         livenessProbe:
           exec:
+          {{- if .Values.nginx.livenessProbe.command }}
             command:
-            - curl
-            - localhost:8080/nginx_status
+            {{- toYaml .Values.nginx.livenessProbe.command | nindent 12 }}
+          {{- else -}}
+            command:
+              - curl
+              - localhost:8080/nginx_status
+          {{- end }}
           initialDelaySeconds: {{ .Values.nginx.livenessProbe.initialProbeDelay }}
           failureThreshold: 10
         readinessProbe:
           exec:
+          {{- if .Values.nginx.readinessProbe.command }}
             command:
-            - curl
-            - localhost:8080/nginx_status
+            {{- toYaml .Values.nginx.readinessProbe.command | nindent 12 }}
+          {{- else -}}
+            command:
+              - curl
+              - localhost:8080/nginx_status
+          {{- end }}
           initialDelaySeconds: {{ .Values.nginx.readinessProbe.initialProbeDelay }}
         env:
         - name: "RASA_X_HOST"

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -494,11 +494,15 @@ nginx:
     # externalIPs can be used to expose the service to certain IPs (https://kubernetes.io/docs/concepts/services-networking/service/#external-ips)
     externalIPs: []
   livenessProbe:
-    # initialProbeDelay for the `readinessProbe`
+    # command for the `livenessProbe`
+    command: []
+    # initialProbeDelay for the `livenessProbe`
     initialProbeDelay: 10
   # readinessProbe checks whether rasa x can receive traffic
   readinessProbe:
-    # initialProbeDelay for the `livenessProbe`
+    # command for the `readinessProbe`
+    command: []
+    # initialProbeDelay for the `readinessProbe`
     initialProbeDelay: 10
 
   # tolerations can be used to control the pod to node assignment


### PR DESCRIPTION
make nginx liveness/readiness probe commands configurable so that e.g. when running with SSL it can be changed to port 8443