### PR TITLE
Fix default nginx probes

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "1.8.4"
+version: "1.8.5"
 
 appVersion: "0.38.1"
 

--- a/charts/rasa-x/templates/nginx-deployment.yaml
+++ b/charts/rasa-x/templates/nginx-deployment.yaml
@@ -53,7 +53,7 @@ spec:
           {{- if .Values.nginx.livenessProbe.command }}
             command:
             {{- toYaml .Values.nginx.livenessProbe.command | nindent 12 }}
-          {{- else -}}
+          {{- else }}
             command:
               - curl
               - localhost:8080/nginx_status
@@ -65,7 +65,7 @@ spec:
           {{- if .Values.nginx.readinessProbe.command }}
             command:
             {{- toYaml .Values.nginx.readinessProbe.command | nindent 12 }}
-          {{- else -}}
+          {{- else }}
             command:
               - curl
               - localhost:8080/nginx_status


### PR DESCRIPTION
The chart version including https://github.com/RasaHQ/rasa-x-helm/pull/168 broke for us with the error 

```
Error: Failed to render chart: exit status 1: Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: [ValidationError(Deployment.spec.template.spec.containers[0].livenessProbe): unknown field "exec:command" in io.k8s.api.core.v1.Probe, ValidationError(Deployment.spec.template.spec.containers[0].readinessProbe): unknown field "exec:command" in io.k8s.api.core.v1.Probe]
```

When not overwriting the nginx probes, the chart in version 4d1a1f19a19d5c20a30126deffe669a1c71ae9e8 renders as:

```yaml
        image: "rasa/nginx:0.38.1"
        imagePullPolicy: Always
        ports:
        - name: "http"
          containerPort: 8080
          protocol: "TCP"
        livenessProbe:
          exec:command: # <<< here lies the issue
              - curl
              - localhost:8080/nginx_status
          initialDelaySeconds: 10
```

(generated using `helm template . | grep 'image: "rasa/nginx:0.38.1"' -A 10`), with my patch it looks correct again:

```yaml
image: "rasa/nginx:0.38.1"
        imagePullPolicy: Always
        ports:
        - name: "http"
          containerPort: 8080
          protocol: "TCP"
        livenessProbe:
          exec:
            command:
              - curl
              - localhost:8080/nginx_status
          initialDelaySeconds: 10
```