### PR TITLE
make nodes selectable per rasa version

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "1.8.5"
+version: "1.8.6"
 
 appVersion: "0.38.1"
 

--- a/charts/rasa-x/templates/rasa-deployments.yaml
+++ b/charts/rasa-x/templates/rasa-deployments.yaml
@@ -29,9 +29,9 @@ spec:
     spec:
       automountServiceAccountToken: {{ $.Values.rasa.automountServiceAccountToken }}
       {{ include "rasa-x.spec" $ }}
-      {{- if $.Values.rasa.nodeSelector }}
+      {{- if .nodeSelector }}
       nodeSelector:
-{{ toYaml $.Values.rasa.nodeSelector | indent 8 }}
+{{ toYaml .nodeSelector | indent 8 }}
       {{- end }}
       {{- if $.Values.rasa.tolerations }}
       tolerations:

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -176,11 +176,6 @@ rasa:
     # - key: "nvidia.com/gpu"
     #   operator: "Exists"
 
-  # nodeSelector to specify which node the pods should run on
-  # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
-  nodeSelector: {}
-    # "beta.kubernetes.io/instance-type": "g3.8xlarge"
-
   # automountServiceAccountToken specifies whether the Kubernetes service account
   # credentials should be automatically mounted into the pods. See more about it in
   # https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server
@@ -194,6 +189,10 @@ rasa:
   versions:
     # rasaProduction is the container which serves the production environment
     rasaProduction:
+      # nodeSelector to specify which node the pods should run on
+      # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+      nodeSelector: {}
+        # "beta.kubernetes.io/instance-type": "g3.8xlarge"
       # replicaCount of the Rasa Production container
       replicaCount: 1
       # serviceName with which the Rasa production deployment is exposed to other containers
@@ -221,6 +220,10 @@ rasa:
       #   emptyDir: {}
     # rasaWorker is the container which does computational heavy tasks such as training
     rasaWorker:
+      # nodeSelector to specify which node the pods should run on
+      # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+      nodeSelector: {}
+        # "beta.kubernetes.io/instance-type": "g3.8xlarge"
       # replicaCount of the Rasa worker container
       replicaCount: 1
       # serviceName with which the Rasa worker deployment is exposed to other containers


### PR DESCRIPTION
Move `nodeSelector` under `rasa.versions` so that e.g. worker can select a node with specific requirements that prod does not share or vice versa