### PR TITLE
split rasa open source ingress to fix forwarding

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "1.10.1"
+version: "1.10.2"
 
 appVersion: "0.39.3"
 

--- a/charts/rasa-x/templates/rasa-open-source-api-ingress.yaml
+++ b/charts/rasa-x/templates/rasa-open-source-api-ingress.yaml
@@ -9,7 +9,7 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
-  name: {{ $fullName }}-rasa-open-source
+  name: {{ $fullName }}-rasa-open-source-api
   labels:
     {{- include "rasa-x.labels" . | nindent 4 }}
   annotations:
@@ -45,20 +45,6 @@ spec:
               number: {{ $.Values.rasa.port }}
         path: /core/(.*)
         pathType: Prefix
-      - backend:
-          service:
-            name: {{ $fullName }}-{{ $.Values.rasa.versions.rasaProduction.serviceName }}
-            port:
-              number: {{ $.Values.rasa.port }}
-        path: /webhooks/
-        pathType: Prefix
-      - backend:
-          service:
-            name: {{ $fullName }}-{{ $.Values.rasa.versions.rasaProduction.serviceName }}
-            port:
-              number: {{ $.Values.rasa.port }}
-        path: /socket.io
-        pathType: Prefix
     {{- end }}
 {{- else -}}
     {{- range .Values.ingress.hosts }}
@@ -69,14 +55,6 @@ spec:
           serviceName: {{ $fullName }}-{{ $.Values.rasa.versions.rasaProduction.serviceName }}
           servicePort: {{ $.Values.rasa.port }}
         path: /core/(.*)
-      - backend:
-          serviceName: {{ $fullName }}-{{ $.Values.rasa.versions.rasaProduction.serviceName }}
-          servicePort: {{ $.Values.rasa.port }}
-        path: /webhooks/
-      - backend:
-          serviceName: {{ $fullName }}-{{ $.Values.rasa.versions.rasaProduction.serviceName }}
-          servicePort: {{ $.Values.rasa.port }}
-        path: /socket.io
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/rasa-x/templates/rasa-open-source-channels-ingress.yaml
+++ b/charts/rasa-x/templates/rasa-open-source-channels-ingress.yaml
@@ -1,0 +1,70 @@
+{{- if and .Values.ingress.enabled (not .Values.nginx.enabled) -}}
+{{- $fullName := include "rasa-x.fullname" . -}}
+{{- if semverCompare ">=1.19" .Capabilities.KubeVersion.Version -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14" .Capabilities.KubeVersion.Version -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-rasa-open-source-channels
+  labels:
+    {{- include "rasa-x.labels" . | nindent 4 }}
+  annotations:
+  {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.ingress.annotationsRasa }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+
+{{- if semverCompare ">=1.19" .Capabilities.KubeVersion.Version -}}
+    {{- range .Values.ingress.hosts }}
+  - host: {{ .host | quote }}
+    http:
+      paths:
+      - backend:
+          service:
+            name: {{ $fullName }}-{{ $.Values.rasa.versions.rasaProduction.serviceName }}
+            port:
+              number: {{ $.Values.rasa.port }}
+        path: /webhooks/
+        pathType: Prefix
+      - backend:
+          service:
+            name: {{ $fullName }}-{{ $.Values.rasa.versions.rasaProduction.serviceName }}
+            port:
+              number: {{ $.Values.rasa.port }}
+        path: /socket.io
+        pathType: Prefix
+    {{- end }}
+{{- else -}}
+    {{- range .Values.ingress.hosts }}
+  - host: {{ .host | quote }}
+    http:
+      paths:
+      - backend:
+          serviceName: {{ $fullName }}-{{ $.Values.rasa.versions.rasaProduction.serviceName }}
+          servicePort: {{ $.Values.rasa.port }}
+        path: /webhooks/
+      - backend:
+          serviceName: {{ $fullName }}-{{ $.Values.rasa.versions.rasaProduction.serviceName }}
+          servicePort: {{ $.Values.rasa.port }}
+        path: /socket.io
+    {{- end }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
fix https://github.com/RasaHQ/rasa-x-helm/issues/193

Split the `rasa-x-rasa-open-source` ingress into two (`rasa-x-rasa-open-source-api` and `rasa-x-rasa-open-source-channels`), allowing the `/core/(.*)` forwarding rule to make use of the [rewrite target annotation](https://github.com/RasaHQ/rasa-x-helm/blob/main/charts/rasa-x/templates/rasa-open-source-ingress.yaml#L16), and the `webhooks/` and `socket.io` annotations to automatically create their respective `proxy_pass`es without the annotation. 