### PR TITLE
Add option to specify more than one rabbit queue

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "1.11.1"
+version: "1.12.0"
 
 appVersion: "0.39.3"
 

--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "1.10.2"
+version: "1.10.3"
 
 appVersion: "0.39.3"
 

--- a/charts/rasa-x/templates/_helpers.tpl
+++ b/charts/rasa-x/templates/_helpers.tpl
@@ -182,11 +182,11 @@ Include rasax extra env vars.
 {{- end -}}
 
 {{/*
-Include additional queues
+Include additional rabbit queues
 */}}
-{{- define "rasa.additionalQueues" -}}
-  {{- if .Values.rasa.additionalQueues -}}
-{{ toYaml .Values.rasa.additionalQueues }}
+{{- define "rasa.additionalRabbitQueues" -}}
+  {{- if .Values.rasa.additionalRabbitQueues -}}
+{{ toYaml .Values.rasa.additionalRabbitQueues }}
   {{- end -}}
 {{- end -}}
 

--- a/charts/rasa-x/templates/_helpers.tpl
+++ b/charts/rasa-x/templates/_helpers.tpl
@@ -182,6 +182,15 @@ Include rasax extra env vars.
 {{- end -}}
 
 {{/*
+Include additional queues
+*/}}
+{{- define "rasa.additionalQueues" -}}
+  {{- if .Values.rasa.additionalQueues -}}
+{{ toYaml .Values.rasa.additionalQueues }}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Include extra env vars for the EventService.
 */}}
 {{- define "rasax.event-service.extra.envs" -}}

--- a/charts/rasa-x/templates/rasa-config-files-configmap.yaml
+++ b/charts/rasa-x/templates/rasa-config-files-configmap.yaml
@@ -37,10 +37,12 @@ data:
       {{ if or (regexMatch ".*(a|rc)[0-9]+" .Values.rasa.version) (regexMatch "2.*[0-9]+-full" .Values.rasa.version) -}}
       queues:
       - ${RABBITMQ_QUEUE}
+      {{- include  "rasa.additionalQueues" $ | nindent 6 }}
       {{- else -}}
       {{ if semverCompare ">= 1.9.0" .Values.rasa.version -}}
       queues:
       - ${RABBITMQ_QUEUE}
+      {{- include  "rasa.additionalQueues" $ | nindent 6 }}
       {{- else -}}
       queue: ${RABBITMQ_QUEUE}
       {{- end }}

--- a/charts/rasa-x/templates/rasa-config-files-configmap.yaml
+++ b/charts/rasa-x/templates/rasa-config-files-configmap.yaml
@@ -37,12 +37,12 @@ data:
       {{ if or (regexMatch ".*(a|rc)[0-9]+" .Values.rasa.version) (regexMatch "2.*[0-9]+-full" .Values.rasa.version) -}}
       queues:
       - ${RABBITMQ_QUEUE}
-      {{- include  "rasa.additionalQueues" $ | nindent 6 }}
+      {{- include  "rasa.additionalRabbitQueues" $ | nindent 6 }}
       {{- else -}}
       {{ if semverCompare ">= 1.9.0" .Values.rasa.version -}}
       queues:
       - ${RABBITMQ_QUEUE}
-      {{- include  "rasa.additionalQueues" $ | nindent 6 }}
+      {{- include  "rasa.additionalRabbitQueues" $ | nindent 6 }}
       {{- else -}}
       queue: ${RABBITMQ_QUEUE}
       {{- end }}

--- a/charts/rasa-x/templates/rasa-deployments.yaml
+++ b/charts/rasa-x/templates/rasa-deployments.yaml
@@ -127,8 +127,6 @@ spec:
               key: {{ template "rasa-x.redis.password.key" $ }}
         {{- end }}
         {{- if $.Values.rabbitmq.enabled }}
-        - name: "RABBITMQ_QUEUE"
-          value: "{{ $.Values.rasa.rabbitQueue }}"
         - name: "RABBITMQ_PASSWORD"
           valueFrom:
             secretKeyRef:

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -128,6 +128,8 @@ rasa:
   token: "rasaToken"
   # rabbitQueue it should use to dispatch events to Rasa X
   rabbitQueue: "rasa_production_events"
+  # Optional additional rabbit queues for e.g. connecting to an analytics stack
+  additionalQueues: []
   # additionalChannelCredentials which should be used by Rasa to connect to various
   # input channels
   additionalChannelCredentials: {}
@@ -663,7 +665,7 @@ postgresql:
   #   fsGroup: 1001
   #   runAsUser: 1001
 
-# RabbitMQ specific settings (https://hub.helm.sh/charts/bitnami/rabbitmq/6.19.2)
+# RabbitMQ specific settings (https://hub.helm.sh/charts/bitnami/rabbitmq/7.8.0)
 rabbitmq:
   # Install should be `true` if the rabbitmq subchart should be used
   install: true

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -665,7 +665,7 @@ postgresql:
   #   fsGroup: 1001
   #   runAsUser: 1001
 
-# RabbitMQ specific settings (https://hub.helm.sh/charts/bitnami/rabbitmq/7.8.0)
+# RabbitMQ specific settings (https://hub.helm.sh/charts/bitnami/rabbitmq/6.19.2)
 rabbitmq:
   # Install should be `true` if the rabbitmq subchart should be used
   install: true

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -129,7 +129,7 @@ rasa:
   # rabbitQueue it should use to dispatch events to Rasa X
   rabbitQueue: "rasa_production_events"
   # Optional additional rabbit queues for e.g. connecting to an analytics stack
-  additionalQueues: []
+  additionalRabbitQueues: []
   # additionalChannelCredentials which should be used by Rasa to connect to various
   # input channels
   additionalChannelCredentials: {}


### PR DESCRIPTION
- Add template to include list of multiple rabbit queues as is possible in a docker-compose deployment for adding e.g. a queue for ELK to consume from