### PR TITLE
Configure duckling url

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "1.13.1"
+version: "1.13.2"
 
 appVersion: "0.40.1"
 

--- a/charts/rasa-x/templates/rasa-deployments.yaml
+++ b/charts/rasa-x/templates/rasa-deployments.yaml
@@ -139,8 +139,10 @@ spec:
           value: "{{ .rasaEnvironment }}"
         - name: "RASA_MODEL_SERVER"
           value: {{ $.Values.rasax.scheme }}://{{ include "rasa-x.host" $ }}.{{ $.Release.Namespace }}.svc:{{ $.Values.rasax.port }}/api/projects/default/models/tags/{{ .modelTag }}
+        {{- if $.Values.duckling.enabled }}
         - name: "RASA_DUCKLING_HTTP_URL"
-          value: {{ if $.Values.duckling.existingUrl }}"{{ $.Values.duckling.existingUrl }}"{{ else }}"{{ $.Values.duckling.scheme }}://{{ include "duckling.host" $ }}.{{ $.Release.Namespace }}.svc:{{ $.Values.duckling.port }}"{{ end }}
+          value: {{ $.Values.duckling.scheme }}://{{ include "duckling.host" $ }}.{{ $.Release.Namespace }}.svc:{{ $.Values.duckling.port }}
+        {{- end }}
         {{- include "rasa.extra.envs" $ | nindent 8 }}
         volumeMounts:
         # Mount the temporary directory for the Rasa global configuration

--- a/charts/rasa-x/templates/rasa-deployments.yaml
+++ b/charts/rasa-x/templates/rasa-deployments.yaml
@@ -140,7 +140,7 @@ spec:
         - name: "RASA_MODEL_SERVER"
           value: {{ $.Values.rasax.scheme }}://{{ include "rasa-x.host" $ }}.{{ $.Release.Namespace }}.svc:{{ $.Values.rasax.port }}/api/projects/default/models/tags/{{ .modelTag }}
         - name: "RASA_DUCKLING_HTTP_URL"
-          value: {{ $.Values.duckling.scheme }}://{{ include "duckling.host" $ }}.{{ $.Release.Namespace }}.svc:{{ $.Values.duckling.port }}
+          value: {{ if $.Values.duckling.existingUrl }}"{{ $.Values.duckling.existingUrl }}"{{ else }}"{{ $.Values.duckling.scheme }}://{{ include "duckling.host" $ }}.{{ $.Release.Namespace }}.svc:{{ $.Values.duckling.port }}"{{ end }}
         {{- include "rasa.extra.envs" $ | nindent 8 }}
         volumeMounts:
         # Mount the temporary directory for the Rasa global configuration

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -565,6 +565,9 @@ duckling:
   args: []
   # Enable or disable duckling
   enabled: true
+  # if you are using an existing Duckling server configure the URL here
+  # #existingUrl: http://myducklingserver:5055
+  #  
   # name of the Duckling image to use
   name: "rasa/duckling"
   # tag refers to the duckling image tag

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -565,9 +565,6 @@ duckling:
   args: []
   # Enable or disable duckling
   enabled: true
-  # if you are using an existing Duckling server configure the URL here
-  # #existingUrl: http://myducklingserver:5055
-  #  
   # name of the Duckling image to use
   name: "rasa/duckling"
   # tag refers to the duckling image tag


### PR DESCRIPTION
Allow users to disable the default Duckling image and provide a `RASA_DUCKLING_HTTP_URL ` within the `extraEnvs` section of the `rasa` service.