### PR TITLE
Set ingress to false by default

### DIFF
--- a/.github/deployments/rasa-x-helmfile.yaml
+++ b/.github/deployments/rasa-x-helmfile.yaml
@@ -17,6 +17,7 @@ releases:
       - nginx:
           enabled: false
       - ingress:
+          enabled: true
           annotations:
             kubernetes.io/ingress.class: nginx
             nginx.ingress.kubernetes.io/enable-cors: "true"

--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "1.13.1"
+version: "1.14.0"
 
 appVersion: "0.40.1"
 

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -718,9 +718,9 @@ redis:
 # ingress settings
 ingress:
   # enabled should be `true` if you want to use this ingress.
-  # Note that if `nginx.enabled` is `true` the `rasa/nginx` image is used as reverse proxy.
+  # Note that if `nginx.enabled` is `true` the `nginx` image is used as reverse proxy.
   # In order to use nginx ingress you have to set `nginx.enabled=false`.
-  enabled: true
+  enabled: false
   # annotations for the ingress - annotations are applied for the rasa and rasax ingresses
   annotations: {}
     # kubernetes.io/ingress.class: nginx


### PR DESCRIPTION
Also requested here: https://github.com/RasaHQ/rasa-x-helm/issues/12

I think we should have either nginx or ingress enabled by default. Currently, both are enabled. So with this PR I wanted to set nginx to the default by changing ingress enabled to false.

Also, in the comment we still referred to the nginx image as `rasa/nginx`, so I removed the rasa piece since we're no longer pulling our custom image.