### PR TITLE
Add the disableTelemetry parameter for Rasa OSS

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "1.13.1"
+version: "1.14.0"
 
 appVersion: "0.40.1"
 

--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "1.14.0"
+version: "1.15.0"
 
 appVersion: "0.40.1"
 

--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "1.15.0"
+version: "1.16.0"
 
 appVersion: "0.40.1"
 

--- a/charts/rasa-x/templates/rasa-deployments.yaml
+++ b/charts/rasa-x/templates/rasa-deployments.yaml
@@ -91,7 +91,7 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
         env:
-        {{- if eq "true" (include "is_enterprise" $) }}
+        {{- if or (eq "true" (include "is_enterprise" $)) $.Values.rasa.disableTelemetry }}
         - name: "RASA_TELEMETRY_ENABLED"
           value: "false"
         {{ end }}

--- a/charts/rasa-x/templates/rasa-x-deployment.yaml
+++ b/charts/rasa-x/templates/rasa-x-deployment.yaml
@@ -68,7 +68,7 @@ spec:
           initialDelaySeconds: {{ .Values.rasax.readinessProbe.initialProbeDelay }}
           failureThreshold: 10
         env:
-        {{- if eq "true" (include "is_enterprise" .) }}
+        {{- if or (eq "true" (include "is_enterprise" .)) .Values.rasax.disableTelemetry }}
         - name: "RASA_TELEMETRY_ENABLED"
           value: "false"
         {{ end }}

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -110,6 +110,8 @@ rasa:
   # version is the Rasa Open Source version which should be used.
   # Used to ensure backward compatibility with older Rasa Open Source versions.
   version: "2.4.3"  # Please update the default value in the Readme when updating this
+  # disableTelemetry permanently disables telemetry
+  disableTelemetry: false
   # override the default command to run in the container
   command: []
   # override the default arguments to run in the container
@@ -474,7 +476,7 @@ app:
     initialProbeDelay: 10
     # scheme to be used by the `readinessProbe`
     scheme: "HTTP"
-    
+
   # podLabels adds additional pod labels
   # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   podLabels: {}


### PR DESCRIPTION
- Add the `disableTelemetry` parameter for Rasa OSS - currently, it's automatically disabled if Rasa Enterprise is used