### PR TITLE
Use Rasabot token

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -27,7 +27,7 @@ jobs:
       if: startsWith(steps.changelog.outputs.changelog, '####')
       run: |
         # Get release id
-        RELEASE_ID=$(curl -s -H "Authorization: token ${{ secrets.RASABOT_GITHUB_TOKEN }}" \
+        RELEASE_ID=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
           -H "Accept: application/vnd.github.v3+json" \
           "https://api.github.com/repos/${{ github.repository }}/releases/latest" | jq '.id')
 
@@ -35,7 +35,7 @@ jobs:
         RELEASE_BODY="${RELEASE_BODY//$'\n'/'\n'}"
 
         # Update release body
-        curl -X PATCH -s -H "Authorization: token ${{ secrets.RASABOT_GITHUB_TOKEN }}" \
+        curl -X PATCH -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
           -H "Accept: application/vnd.github.v3+json" \
           "https://api.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}" \
           -d "{\"body\":\"$RELEASE_BODY\"}"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -27,7 +27,7 @@ jobs:
       if: startsWith(steps.changelog.outputs.changelog, '####')
       run: |
         # Get release id
-        RELEASE_ID=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+        RELEASE_ID=$(curl -s -H "Authorization: token ${{ secrets.RASABOT_GITHUB_TOKEN }}" \
           -H "Accept: application/vnd.github.v3+json" \
           "https://api.github.com/repos/${{ github.repository }}/releases/latest" | jq '.id')
 
@@ -35,7 +35,7 @@ jobs:
         RELEASE_BODY="${RELEASE_BODY//$'\n'/'\n'}"
 
         # Update release body
-        curl -X PATCH -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+        curl -X PATCH -s -H "Authorization: token ${{ secrets.RASABOT_GITHUB_TOKEN }}" \
           -H "Accept: application/vnd.github.v3+json" \
           "https://api.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}" \
           -d "{\"body\":\"$RELEASE_BODY\"}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,6 @@ jobs:
         helm repo add bitnami https://charts.bitnami.com/bitnami
 
     - name: Run chart-releaser
-      uses: helm/chart-releaser-action@v1.1.0
+      uses: helm/chart-releaser-action@c25b74a986eb925b398320414b576227f375f946  # v1.2.1
       env:
-        CR_TOKEN: "${{ secrets.CR_TOKEN }}"
+        CR_TOKEN: "${{ secrets.RASABOT_GITHUB_TOKEN }}"

--- a/.github/workflows/update_rasa_x_version.yml
+++ b/.github/workflows/update_rasa_x_version.yml
@@ -69,7 +69,7 @@ jobs:
         uses: peterjgrainger/action-create-branch@v2.0.1
         if: env.CREATE_UPDATE_PR == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RASABOT_GITHUB_TOKEN }}
         with:
           branch: ${{ steps.get-branch-name.outputs.new_branch }}
 
@@ -92,7 +92,7 @@ jobs:
         uses: repo-sync/pull-request@v2
         if: env.CREATE_UPDATE_PR == 'true'
         with:
-          github_token:  ${{ secrets.GITHUB_TOKEN }}
+          github_token:  ${{ secrets.RASABOT_GITHUB_TOKEN }}
           source_branch: ${{ steps.get-branch-name.outputs.new_branch }}
           destination_branch: main
           pr_title: Bump Rasa X version to ${LATEST_RASA_X_MINOR}


### PR DESCRIPTION
**The problem**

PRs created by `GITHUB_TOKEN` do not trigger any workflow runs. 

Examples: 
- https://github.com/RasaHQ/rasa-x-helm/pull/213
- https://github.com/RasaHQ/rasa-x-helm/pull/214

> When you use the repository's `GITHUB_TOKEN` to perform tasks on behalf of the GitHub Actions app, events triggered by the GITHUB_TOKEN will not create a new workflow run. 
> Ref: https://docs.github.com/en/actions/reference/authentication-in-a-workflow

**Proposed changes**

Replace all `GITHUB_TOKEN` secret to Rasabot.

