### PR TITLE
fix: Add network policies for Kubernetes API and redis

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "2.0.0"
+version: "2.0.1"
 
 appVersion: "0.41.1"
 
@@ -42,8 +42,4 @@ annotations:
   # See: https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations
   artifacthub.io/changes: |
     - kind: added
-      description: Support for an external Rasa OSS deployment
-    - kind: changed
-      description: Bump Rasa OSS version to 2.7.1
-    - kind: changed
-      description: Bump Rasa X version to 0.41.1
+      description: Add network policies for Kubernetes API (the rabbitmq_peer_discovery_k8s plugin) and redis

--- a/charts/rasa-x/templates/network-policy.yaml
+++ b/charts/rasa-x/templates/network-policy.yaml
@@ -270,7 +270,46 @@ spec:
       ports:
       - protocol: TCP
         port: {{ default 6379 .Values.redis.redisPort }}
-
+---
+apiVersion: {{ template "networkPolicy.apiVersion" . }}
+kind: NetworkPolicy
+metadata:
+  name: egress-from-event-service-to-redis
+  namespace: {{ .Release.Namespace }}
+spec:
+  policyTypes:
+    - Egress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: event-service
+  egress:
+    - to:
+      - podSelector:
+          matchLabels:
+              app: redis
+      ports:
+      - protocol: TCP
+        port: {{ default 6379 .Values.redis.redisPort }}
+---
+apiVersion: {{ template "networkPolicy.apiVersion" . }}
+kind: NetworkPolicy
+metadata:
+  name: ingress-from-event-service-to-redis
+  namespace: {{ .Release.Namespace }}
+spec:
+  policyTypes:
+    - Ingress
+  podSelector:
+    matchLabels:
+      app: redis
+  ingress:
+    - from:
+      - podSelector:
+          matchLabels:
+            app.kubernetes.io/component: event-service
+      ports:
+      - protocol: TCP
+        port: {{ default 6379 .Values.redis.redisPort }}
 ---
 apiVersion: {{ template "networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
@@ -634,7 +673,25 @@ spec:
       - protocol: TCP
         port: {{ coalesce .Values.global.postgresql.servicePort 5432 }}
 {{- end -}}
-{{- if .Values.rabbitmq.install -}}
+{{- if .Values.rabbitmq.install }}
+---
+apiVersion: {{ template "networkPolicy.apiVersion" . }}
+kind: NetworkPolicy
+metadata:
+  name: egress-from-rabbitmq-to-k8s-api
+  namespace: {{ .Release.Namespace }}
+spec:
+  policyTypes:
+    - Egress
+  podSelector:
+    matchLabels:
+      app: rabbitmq
+  egress:
+  - ports:
+      - protocol: TCP
+        port: 8443
+      - protocol: TCP
+        port: 443
 ---
 apiVersion: {{ template "networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
@@ -665,7 +722,7 @@ spec:
   policyTypes:
     - Ingress
   podSelector:
-   matchLabels:
+    matchLabels:
       app: rabbitmq
   ingress:
     - from:
@@ -755,6 +812,22 @@ spec:
       ports:
       - protocol: TCP
         port: {{ default 5672 .Values.rabbitmq.service.port }}
+---
+apiVersion: {{ template "networkPolicy.apiVersion" . }}
+kind: NetworkPolicy
+metadata:
+  name: egress-from-rasa-x-to-https
+  namespace: {{ .Release.Namespace }}
+spec:
+  policyTypes:
+    - Egress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: rasa-x
+  egress:
+    - ports:
+      - protocol: TCP
+        port: 443
 ---
 apiVersion: {{ template "networkPolicy.apiVersion" . }}
 kind: NetworkPolicy


### PR DESCRIPTION
Add network policies for Kubernetes API (the rabbitmq_peer_discovery_k8s plugin) and redis