### PR TITLE
Switch user 'me' for 'admin'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
 
     - name: Validate that logging in works ✅
       run: |
-        TOKEN=$(curl --fail --data '{"username": "me", "password": "'${INITIAL_USER_PASSWORD}'"}' "http://${HOST}/api/auth" | jq -r '.access_token')
+        TOKEN=$(curl --fail --data '{"username": "admin", "password": "'${INITIAL_USER_PASSWORD}'"}' "http://${HOST}/api/auth" | jq -r '.access_token')
         if [[ -z "${TOKEN}" ]]; then
           echo "Access token is empty: ${TOKEN}" && exit 1
         fi

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -32,7 +32,7 @@ rasax:
   # initialUser is the user which is created upon the initial start of Rasa X
   initialUser:
     # username specifies a name of this user
-    username: "me"
+    username: "admin"
     # password for this user (leave it empty to skip the user creation)
     password: ""
   ## Enable persistence using Persistent Volume Claims


### PR DESCRIPTION
After the Rasa X / Enterprise project structure refactor, the default user is now `admin` across both versions of the platform.