### PR TITLE
fix: Set an empty map for the `rasa` key if environments are not defined

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "2.4.1"
+version: "2.4.2"
 
 appVersion: "0.42.0"
 
@@ -42,4 +42,4 @@ annotations:
   # See: https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations
   artifacthub.io/changes: |
     - kind: fixed
-      description: Include the 'rasa' key into the environment's configuration.
+      description: Set an empty map for the 'rasa' key if environments are not defined.

--- a/charts/rasa-x/templates/_helpers.tpl
+++ b/charts/rasa-x/templates/_helpers.tpl
@@ -358,3 +358,26 @@ Return DNS policy depends on host network configuration
 {{- .Values.rasax.dnsPolicy -}}
 {{- end -}}
 {{- end -}}
+
+
+{{/*
+Return 'true' if the production environment is used.
+*/}}
+{{- define "rasa-x.production.env.used" -}}
+{{- if or .Values.rasa.versions.rasaProduction.enabled .Values.rasa.versions.rasaProduction.external.enabled  -}}
+{{- print "true" -}}
+{{- else -}}
+{{- print "false" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return 'true' if the worker environment is used.
+*/}}
+{{- define "rasa-x.worker.env.used" -}}
+{{- if or .Values.rasa.versions.rasaWorker.enabled .Values.rasa.versions.rasaWorker.external.enabled  -}}
+{{- print "true" -}}
+{{- else -}}
+{{- print "false" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/rasa-x/templates/rasa-x-config-files-configmap.yaml
+++ b/charts/rasa-x/templates/rasa-x-config-files-configmap.yaml
@@ -6,13 +6,17 @@ metadata:
     {{ include "rasa-x.labels" . | nindent 4 }}
 data:
   environments: |
+{{- if or (eq (include "rasa-x.production.env.used" .) "true") (eq (include "rasa-x.worker.env.used" .) "true") }}
     rasa:
-{{- if or .Values.rasa.versions.rasaProduction.enabled .Values.rasa.versions.rasaProduction.external.enabled }}
+{{- else }}
+    rasa: {}
+{{- end }}
+{{- if eq (include "rasa-x.production.env.used" .) "true" }}
       production:
         url: "{{- include "rasa.production.url" .}}"
         token: ${RASA_TOKEN}
 {{- end }}
-{{- if or .Values.rasa.versions.rasaWorker.enabled .Values.rasa.versions.rasaWorker.external.enabled }}
+{{- if eq (include "rasa-x.worker.env.used" .) "true"  }}
       worker:
         url: "{{- include "rasa.worker.url" .}}"
         token: ${RASA_TOKEN}


### PR DESCRIPTION
- Set an empty map for the 'rasa' key if environments are not defined