### PR TITLE
refactor: Use the same image for the init-db container as for the main container

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "2.9.0"
+version: "2.10.0"
 
 appVersion: "0.42.4"
 
@@ -41,5 +41,8 @@ dependencies:
 annotations:
   # See: https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations
   artifacthub.io/changes: |
-    - kind: added
-      description: Add support for defining resources for the init-db container
+    - kind: changed
+      description: Use the same image for the init-db container as for the main container
+      links:
+        - name: GitHub PR
+          url: https://github.com/RasaHQ/rasa-x-helm/pull/251

--- a/charts/rasa-x/templates/event-service-deployment.yaml
+++ b/charts/rasa-x/templates/event-service-deployment.yaml
@@ -35,7 +35,8 @@ spec:
       # Use the init-db init container to check if database migration is completed.
       # The event service uses a database, to make sure that the database is ready
       # to use we use the database migration service to check migration status.
-      {{- include "initContainer.dbMigration" . |  nindent 6 }}
+      {{- $image := printf "%s:%s" .Values.eventService.name (.Values.eventService.tag | default (include "rasa-x.version" .)) -}}
+      {{- include "initContainer.dbMigration" (dict "context" $ "image" $image ) |  nindent 6 }}
 
       containers:
       - name: {{ .Chart.Name }}

--- a/charts/rasa-x/templates/rasa-deployments.yaml
+++ b/charts/rasa-x/templates/rasa-deployments.yaml
@@ -42,7 +42,7 @@ spec:
       # The rasa service depends on the rasa x server, to make sure that the database is ready
       # and the rasa x server is fully operational we use the database migration service
       # to check migration status.
-      {{- include "initContainer.dbMigration" $ |  nindent 6 }}
+      {{- include "initContainer.dbMigration" (dict "context" $ "image" (printf "%s:%s" $.Values.rasa.name (include "rasa.tag" $))) |  nindent 6 }}
       containers:
       - name: {{ $.Chart.Name }}
         image: '{{ $.Values.rasa.name }}:{{ include "rasa.tag" $ }}'

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -300,8 +300,6 @@ rasa:
 dbMigrationService:
   # initContainer describes settings related to the init-db container used as a init container for deployments
   initContainer:
-    # image is the Docker image which is used by the init container
-    image: alpine:3.12.3
     # command overrides the default command to run in the init container
     command: []
     # resources which initContainer is required / allowed to use


### PR DESCRIPTION
- Use the same image for the init-db container as for the main container
- Resolves #249 