### PR TITLE
breaking: Update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ Update chart dependencies to the latest available version, below you can find li
 
   A full list of changes between versions for the Bitnami RabbitMQ chart can be found [here](https://artifacthub.io/packages/helm/bitnami/rabbitmq).
 
+* RabbitMQ - the chart for PostgreSQL is updated to version 10.
+
+  - Default PostgresSQL version is updated from `12.8.0` to `12.9.0` (a dump/restore is not required for those running 12.X)
+  - The term `master` has been replaced with `primary` and `slave` with `readReplicas` throughout the chart. Role names have changed from `master` and `slave` to `primary` and `read`.
+
+  A full list of changes between versions for the Bitnami RabbitMQ chart can be found [here](https://artifacthub.io/packages/helm/bitnami/postgresql).
+
 ## To 3.0.0
 
 The rasa-x-helm chart in version 3.0.0 introduces the following breaking changes:

--- a/README.md
+++ b/README.md
@@ -35,6 +35,21 @@ helm upgrade <your release name> rasa-x/rasa-x
 helm delete <your release name>
 ```
 
+## To 4.0.0
+
+The rasa-x-helm chart in version 4.0.0 introduces the following breaking changes:
+
+Update chart dependencies to the latest available version:
+
+* Redis - Redis chart is update to version 15, below you can find listed a summary of major changes compare to the previous version used by the rasa-x-helm chart.
+
+  - Credentials parameter are reorganized under the `auth` parameter.
+  - The `cluster.enabled` parameter is deprecated in favor of `architecture` parameter that accepts two values: `standalone` and `replication`.
+  - `securityContext.*` is deprecated in favor of `XXX.podSecurityContext` and `XXX.containerSecurityContext` (`XXX` can be replaces with `master` or `replica`).
+  - `redis.redisPort` is deprecated in favor of `master.service.port` and `replica.service.port`.
+
+A full list of changes between versions for the Bitnami Redis chart can be found [here](https://artifacthub.io/packages/helm/bitnami/redis).
+
 ## To 3.0.0
 
 The rasa-x-helm chart in version 3.0.0 introduces the following breaking changes:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Update chart dependencies to the latest available version, below you can find li
   - `securityContext.*` is deprecated in favor of `XXX.podSecurityContext` and `XXX.containerSecurityContext` (`XXX` can be replaces with `master` or `replica`).
   - `redis.redisPort` is deprecated in favor of `master.service.port` and `replica.service.port`.
 
-  A full list of changes between versions for the Bitnami Redis chart can be found [here](https://artifacthub.io/packages/helm/bitnami/redis).
+  A full list of changes between 10.5.14 and 15.7.4 versions for the Bitnami Redis chart can be found in the [changelog](https://artifacthub.io/packages/helm/bitnami/redis#to-15-0-0).
 
 * RabbitMQ - the chart for RabbitMQ is updated to version 8.
 
@@ -56,14 +56,14 @@ Update chart dependencies to the latest available version, below you can find li
   - Authentication parameters were reorganized under the `auth.*` parameter:
     - `rabbitmq.username`, `rabbitmq.password`, and `rabbitmq.erlangCookie` are now `auth.username`, `auth.password`, and `auth.erlangCookie` respectively.
 
-  A full list of changes between versions for the Bitnami RabbitMQ chart can be found [here](https://artifacthub.io/packages/helm/bitnami/rabbitmq).
+  A full list of changes between 6.19.2 and 8.26.0 versions for the Bitnami RabbitMQ chart can be found in the [changelog](https://artifacthub.io/packages/helm/bitnami/rabbitmq#to-8-21-0).
 
-* RabbitMQ - the chart for PostgreSQL is updated to version 10.
+* PostgreSQL - the chart for PostgreSQL is updated to version 10.
 
   - Default PostgresSQL version is updated from `12.8.0` to `12.9.0` (a dump/restore is not required for those running 12.X)
   - The term `master` has been replaced with `primary` and `slave` with `readReplicas` throughout the chart. Role names have changed from `master` and `slave` to `primary` and `read`.
 
-  A full list of changes between versions for the Bitnami RabbitMQ chart can be found [here](https://artifacthub.io/packages/helm/bitnami/postgresql).
+  A full list of changes between 6.19.2 and 8.26.0 versions for the Bitnami RabbitMQ chart can be found in the [changelog](https://artifacthub.io/packages/helm/bitnami/postgresql#to-8-0-0).
 
 ## To 3.0.0
 

--- a/README.md
+++ b/README.md
@@ -39,16 +39,24 @@ helm delete <your release name>
 
 The rasa-x-helm chart in version 4.0.0 introduces the following breaking changes:
 
-Update chart dependencies to the latest available version:
+Update chart dependencies to the latest available version, below you can find listed a summary of major changes compared to the previous version used by the rasa-x-helm chart:
 
-* Redis - Redis chart is update to version 15, below you can find listed a summary of major changes compare to the previous version used by the rasa-x-helm chart.
+* Redis - the chart for Redis is updated to version 15.
 
   - Credentials parameter are reorganized under the `auth` parameter.
   - The `cluster.enabled` parameter is deprecated in favor of `architecture` parameter that accepts two values: `standalone` and `replication`.
   - `securityContext.*` is deprecated in favor of `XXX.podSecurityContext` and `XXX.containerSecurityContext` (`XXX` can be replaces with `master` or `replica`).
   - `redis.redisPort` is deprecated in favor of `master.service.port` and `replica.service.port`.
 
-A full list of changes between versions for the Bitnami Redis chart can be found [here](https://artifacthub.io/packages/helm/bitnami/redis).
+  A full list of changes between versions for the Bitnami Redis chart can be found [here](https://artifacthub.io/packages/helm/bitnami/redis).
+
+* RabbitMQ - the chart for RabbitMQ is updated to version 8.
+
+  - `securityContext.*` is deprecated in favor of `podSecurityContext` and `containerSecurityContext`.
+  - Authentication parameters were reorganized under the `auth.*` parameter:
+    - `rabbitmq.username`, `rabbitmq.password`, and `rabbitmq.erlangCookie` are now `auth.username`, `auth.password`, and `auth.erlangCookie` respectively.
+
+  A full list of changes between versions for the Bitnami RabbitMQ chart can be found [here](https://artifacthub.io/packages/helm/bitnami/rabbitmq).
 
 ## To 3.0.0
 
@@ -135,10 +143,10 @@ recommend to set at least these values:
 | `rasa.command`                         | Override the default command to run in the container.                                                                                                                                        | `[]`               |
 | `rasa.args`                            | Override the default arguments to run in the container.                                                                                                                                      | `[]`               |
 | `rasa.extraArgs`                       | Additional rasa arguments.                                                                                                                                                                   | `[]`               |
-| `rabbitmq.rabbitmq.password`           | Password for RabbitMq.                                                                                                                                                                       | `test`             |
+| `rabbitmq.auth.password`               | Password for RabbitMQ.                                                                                                                                                                       | `test`             |
 | `global.postgresql.postgresqlPassword` | Password for the Postgresql database.                                                                                                                                                        | `password`         |
 | `global.redis.password`                | Password for redis.                                                                                                                                                                          | `password`         |
-| `rasax.tag`                            | Version of Rasa X which you want to use.                                                                                                                                                     | `1.0.1`           |
+| `rasax.tag`                            | Version of Rasa X which you want to use.                                                                                                                                                     | `1.0.1`            |
 | `rasa.version`                         | Version of Rasa Open Source which you want to use.                                                                                                                                           | `2.8.1`            |
 | `rasa.tag`                             | Image tag which should be used for Rasa Open Source. Uses `rasa.version` if empty.                                                                                                           | ``                 |
 | `app.name`                             | Name of your action server image.                                                                                                                                                            | `rasa/rasa-x-demo` |
@@ -153,7 +161,7 @@ recommend to set at least these values:
 | `duckling.args`                        | Override the default arguments to run in the container.                                                                                                                                      | `[]`               |
 | `global.progressDeadlineSeconds`       | Specifies the number of seconds you want to wait for your Deployment to progress before the system reports back that the Deployment has failed progressing.                                  | `600`              |
 | `networkPolicy.enabled`                | If enabled, will generate NetworkPolicy configs for all combinations of internal ingress/egress                                                                                              | `false`            |
-| `postgresql.image.tag` | The PostgreSQL Image tag | `12.8.0` |
+| `postgresql.image.tag`                 | The PostgreSQL Image tag                                                                                                                                                                     | `12.8.0`           |
 
 ## Where to get help
 
@@ -204,7 +212,6 @@ where `type` is the category of the change, `description` is a short sentence to
 - style
 - test
 - doc
-- ...
 
 For more information, please see [here](https://github.com/lob/generate-changelog#usage).
 

--- a/charts/rasa-x/Chart.lock
+++ b/charts/rasa-x/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 8.6.13
+  version: 10.15.1
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 15.7.2
+  version: 15.7.4
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami
-  version: 6.19.2
-digest: sha256:827f392c4e0aa1163fb16a2f8c1f448b9ea0cb43093234edf3af69f428a1ed3e
-generated: "2022-01-11T15:30:08.853697+01:00"
+  version: 8.26.0
+digest: sha256:e5e68596ad301c5f6b26e912c570bd99cbf603f88b60d5c416f4c92a3f8b82ec
+generated: "2022-01-12T13:44:45.71615+01:00"

--- a/charts/rasa-x/Chart.lock
+++ b/charts/rasa-x/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 8.6.13
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 10.5.14
+  version: 15.7.2
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami
   version: 6.19.2
-digest: sha256:1f80702e13e30d2de7801b5f80cf1622dfebded992151f2d07dfe6678c109650
-generated: "2021-06-28T12:31:27.53084+02:00"
+digest: sha256:827f392c4e0aa1163fb16a2f8c1f448b9ea0cb43093234edf3af69f428a1ed3e
+generated: "2022-01-11T15:30:08.853697+01:00"

--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -34,7 +34,7 @@ dependencies:
   condition: redis.install
 
 - name: rabbitmq
-  version: ~6.19.2
+  version: ~8.26.0
   repository: https://charts.bitnami.com/bitnami
   condition: rabbitmq.install
 

--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -24,7 +24,7 @@ maintainers:
 
 dependencies:
 - name: postgresql
-  version: ~8.6.4
+  version: ~10.15.1
   repository: https://charts.bitnami.com/bitnami
   condition: postgresql.install
 

--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "3.1.1"
+version: "4.0.0"
 
 appVersion: "1.0.1"
 
@@ -29,7 +29,7 @@ dependencies:
   condition: postgresql.install
 
 - name: redis
-  version: ~10.5.12
+  version: ~15.7.2
   repository: https://charts.bitnami.com/bitnami
   condition: redis.install
 
@@ -42,4 +42,4 @@ annotations:
   # See: https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations
   artifacthub.io/changes: |
     - kind: changed
-      description: Bump Rasa X version to 1.0.1
+      description: Update dependency for Redis to 15.7.2 version

--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -49,3 +49,5 @@ annotations:
       description: Update dependency for RabbitMQ to 8.26.0 version
     - kind: changed
       description: Change default PostgreSQL version from 12.8.0 to 12.9.0
+    - kind: fixed
+      description: Add network policies that allow for communication between Rasa OSS, Event Service deployments and db-migration-service

--- a/charts/rasa-x/templates/_rabbitmq.tpl
+++ b/charts/rasa-x/templates/_rabbitmq.tpl
@@ -20,7 +20,7 @@ Return the rabbitmq host.
 Return the rabbitmq password secret name.
 */}}
 {{- define "rasa-x.rabbitmq.password.secret" -}}
-{{- default (include "rabbitmq.fullname" .) .Values.rabbitmq.rabbitmq.existingPasswordSecret | quote -}}
+{{- default (include "rabbitmq.fullname" .) .Values.rabbitmq.auth.existingPasswordSecret | quote -}}
 {{- end -}}
 
 {{/*

--- a/charts/rasa-x/templates/network-policy.yaml
+++ b/charts/rasa-x/templates/network-policy.yaml
@@ -249,7 +249,7 @@ spec:
               app: redis
       ports:
       - protocol: TCP
-        port: {{ default 6379 .Values.redis.redisPort }}
+        port: {{ default 6379 .Values.redis.master.service.port }}
 ---
 apiVersion: {{ template "networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
@@ -269,7 +269,7 @@ spec:
               app: redis
       ports:
       - protocol: TCP
-        port: {{ default 6379 .Values.redis.redisPort }}
+        port: {{ default 6379 .Values.redis.master.service.port }}
 ---
 apiVersion: {{ template "networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
@@ -289,7 +289,7 @@ spec:
               app: redis
       ports:
       - protocol: TCP
-        port: {{ default 6379 .Values.redis.redisPort }}
+        port: {{ default 6379 .Values.redis.master.service.port }}
 ---
 apiVersion: {{ template "networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
@@ -309,7 +309,7 @@ spec:
             app.kubernetes.io/component: event-service
       ports:
       - protocol: TCP
-        port: {{ default 6379 .Values.redis.redisPort }}
+        port: {{ default 6379 .Values.redis.master.service.port }}
 ---
 apiVersion: {{ template "networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
@@ -329,7 +329,7 @@ spec:
               app.kubernetes.io/component: {{ .Values.rasa.versions.rasaProduction.serviceName }}
       ports:
       - protocol: TCP
-        port: {{ default 6379 .Values.redis.redisPort }}
+        port: {{ default 6379 .Values.redis.master.service.port }}
 ---
 apiVersion: {{ template "networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
@@ -349,7 +349,7 @@ spec:
               app.kubernetes.io/component: rasa-x
       ports:
       - protocol: TCP
-        port: {{ default 6379 .Values.redis.redisPort }}
+        port: {{ default 6379 .Values.redis.master.service.port }}
 ---
 apiVersion: {{ template "networkPolicy.apiVersion" . }}
 kind: NetworkPolicy

--- a/charts/rasa-x/templates/network-policy.yaml
+++ b/charts/rasa-x/templates/network-policy.yaml
@@ -16,6 +16,130 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+{{ if .Values.rasa.versions.rasaProduction.enabled -}}
+---
+apiVersion: {{ template "networkPolicy.apiVersion" . }}
+kind: NetworkPolicy
+metadata:
+  name: ingress-from-rasa-production-to-db-migration-service
+  namespace: {{ .Release.Namespace }}
+spec:
+  policyTypes:
+    - Ingress
+  podSelector:
+   matchLabels:
+      app.kubernetes.io/component: db-migration-service
+  ingress:
+    - from:
+      - podSelector:
+          matchLabels:
+              app.kubernetes.io/component: {{ .Values.rasa.versions.rasaProduction.serviceName }}
+      ports:
+      - protocol: TCP
+        port: {{ .Values.dbMigrationService.port }}
+---
+apiVersion: {{ template "networkPolicy.apiVersion" . }}
+kind: NetworkPolicy
+metadata:
+  name: egress-from-rasa-production-to-db-migration-service
+  namespace: {{ .Release.Namespace }}
+spec:
+  policyTypes:
+    - Egress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: {{ .Values.rasa.versions.rasaProduction.serviceName }}
+  egress:
+    - to:
+      - podSelector:
+          matchLabels:
+              app.kubernetes.io/component: db-migration-service
+    - ports:
+      - protocol: TCP
+        port: {{ .Values.dbMigrationService.port }}
+{{ end }}
+{{ if .Values.rasa.versions.rasaWorker.enabled -}}
+---
+apiVersion: {{ template "networkPolicy.apiVersion" . }}
+kind: NetworkPolicy
+metadata:
+  name: ingress-from-rasa-worker-to-db-migration-service
+  namespace: {{ .Release.Namespace }}
+spec:
+  policyTypes:
+    - Ingress
+  podSelector:
+   matchLabels:
+      app.kubernetes.io/component: db-migration-service
+  ingress:
+    - from:
+      - podSelector:
+          matchLabels:
+              app.kubernetes.io/component: {{ .Values.rasa.versions.rasaWorker.serviceName }}
+      ports:
+      - protocol: TCP
+        port: {{ .Values.dbMigrationService.port }}
+---
+apiVersion: {{ template "networkPolicy.apiVersion" . }}
+kind: NetworkPolicy
+metadata:
+  name: egress-from-rasa-worker-to-db-migration-service
+  namespace: {{ .Release.Namespace }}
+spec:
+  policyTypes:
+    - Egress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: {{ .Values.rasa.versions.rasaWorker.serviceName }}
+  egress:
+    - to:
+      - podSelector:
+          matchLabels:
+              app.kubernetes.io/component: db-migration-service
+    - ports:
+      - protocol: TCP
+        port: {{ .Values.dbMigrationService.port }}
+{{ end }}
+---
+apiVersion: {{ template "networkPolicy.apiVersion" . }}
+kind: NetworkPolicy
+metadata:
+  name: ingress-from-event-service-to-db-migration-service
+  namespace: {{ .Release.Namespace }}
+spec:
+  policyTypes:
+    - Ingress
+  podSelector:
+   matchLabels:
+      app.kubernetes.io/component: db-migration-service
+  ingress:
+    - from:
+      - podSelector:
+          matchLabels:
+              app.kubernetes.io/component: event-service
+      ports:
+      - protocol: TCP
+        port: {{ .Values.dbMigrationService.port }}
+---
+apiVersion: {{ template "networkPolicy.apiVersion" . }}
+kind: NetworkPolicy
+metadata:
+  name: egress-from-event-service-to-db-migration-service
+  namespace: {{ .Release.Namespace }}
+spec:
+  policyTypes:
+    - Egress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: event-service
+  egress:
+    - to:
+      - podSelector:
+          matchLabels:
+              app.kubernetes.io/component: db-migration-service
+    - ports:
+      - protocol: TCP
+        port: {{ .Values.dbMigrationService.port }}
 ---
 apiVersion: {{ template "networkPolicy.apiVersion" . }}
 kind: NetworkPolicy

--- a/charts/rasa-x/templates/network-policy.yaml
+++ b/charts/rasa-x/templates/network-policy.yaml
@@ -246,7 +246,7 @@ spec:
     - to:
       - podSelector:
           matchLabels:
-              app: redis
+              app.kubernetes.io/name: redis
       ports:
       - protocol: TCP
         port: {{ default 6379 .Values.redis.master.service.port }}
@@ -266,7 +266,7 @@ spec:
     - to:
       - podSelector:
           matchLabels:
-              app: redis
+              app.kubernetes.io/name: redis
       ports:
       - protocol: TCP
         port: {{ default 6379 .Values.redis.master.service.port }}
@@ -286,7 +286,7 @@ spec:
     - to:
       - podSelector:
           matchLabels:
-              app: redis
+              app.kubernetes.io/name: redis
       ports:
       - protocol: TCP
         port: {{ default 6379 .Values.redis.master.service.port }}
@@ -301,7 +301,7 @@ spec:
     - Ingress
   podSelector:
     matchLabels:
-      app: redis
+      app.kubernetes.io/name: redis
   ingress:
     - from:
       - podSelector:
@@ -321,7 +321,7 @@ spec:
     - Ingress
   podSelector:
    matchLabels:
-      app: redis
+      app.kubernetes.io/name: redis
   ingress:
     - from:
       - podSelector:
@@ -341,7 +341,7 @@ spec:
     - Ingress
   podSelector:
    matchLabels:
-      app: redis
+      app.kubernetes.io/name: redis
   ingress:
     - from:
       - podSelector:
@@ -488,7 +488,7 @@ spec:
     - to:
       - podSelector:
           matchLabels:
-              app: postgresql
+              app.kubernetes.io/name: postgresql
       ports:
       - protocol: TCP
         port: {{ coalesce .Values.global.postgresql.servicePort 5432 }}
@@ -503,7 +503,7 @@ spec:
     - Ingress
   podSelector:
    matchLabels:
-      app: postgresql
+      app.kubernetes.io/name: postgresql
   ingress:
     - from:
       - podSelector:
@@ -528,7 +528,7 @@ spec:
     - to:
       - podSelector:
           matchLabels:
-              app: postgresql
+              app.kubernetes.io/name: postgresql
       ports:
       - protocol: TCP
         port: {{ coalesce .Values.global.postgresql.servicePort 5432 }}
@@ -543,7 +543,7 @@ spec:
     - Ingress
   podSelector:
    matchLabels:
-      app: postgresql
+      app.kubernetes.io/name: postgresql
   ingress:
     - from:
       - podSelector:
@@ -568,7 +568,7 @@ spec:
     - to:
       - podSelector:
           matchLabels:
-              app: postgresql
+              app.kubernetes.io/name: postgresql
       ports:
       - protocol: TCP
         port: {{ coalesce .Values.global.postgresql.servicePort 5432 }}
@@ -583,7 +583,7 @@ spec:
     - Ingress
   podSelector:
    matchLabels:
-      app: postgresql
+      app.kubernetes.io/name: postgresql
   ingress:
     - from:
       - podSelector:
@@ -608,7 +608,7 @@ spec:
     - to:
       - podSelector:
           matchLabels:
-              app: postgresql
+              app.kubernetes.io/name: postgresql
       ports:
       - protocol: TCP
         port: {{ coalesce .Values.global.postgresql.servicePort 5432 }}
@@ -623,7 +623,7 @@ spec:
     - Ingress
   podSelector:
    matchLabels:
-      app: postgresql
+      app.kubernetes.io/name: postgresql
   ingress:
     - from:
       - podSelector:
@@ -648,7 +648,7 @@ spec:
     - to:
       - podSelector:
           matchLabels:
-              app: postgresql
+              app.kubernetes.io/name: postgresql
       ports:
       - protocol: TCP
         port: {{ coalesce .Values.global.postgresql.servicePort 5432 }}
@@ -663,7 +663,7 @@ spec:
     - Ingress
   podSelector:
    matchLabels:
-      app: postgresql
+      app.kubernetes.io/name: postgresql
   ingress:
     - from:
       - podSelector:
@@ -683,7 +683,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: rabbitmq
+      app.kubernetes.io/name: rabbitmq
   ingress:
     - ports:
         - port: 4369  # EPMD
@@ -694,7 +694,7 @@ spec:
       from:
         - podSelector:
             matchLabels:
-              app: rabbitmq
+              app.kubernetes.io/name: rabbitmq
   egress:
     - ports:
         - port: 4369  # EPMD
@@ -705,7 +705,7 @@ spec:
       to:
         - podSelector:
             matchLabels:
-              app: rabbitmq
+              app.kubernetes.io/name: rabbitmq
 ---
 apiVersion: {{ template "networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
@@ -717,7 +717,7 @@ spec:
     - Egress
   podSelector:
     matchLabels:
-      app: rabbitmq
+      app.kubernetes.io/name: rabbitmq
   egress:
   - ports:
       - protocol: TCP
@@ -740,7 +740,7 @@ spec:
     - to:
       - podSelector:
           matchLabels:
-              app: rabbitmq
+              app.kubernetes.io/name: rabbitmq
       ports:
       - protocol: TCP
         port: {{ default 5672 .Values.rabbitmq.service.port }}
@@ -755,7 +755,7 @@ spec:
     - Ingress
   podSelector:
     matchLabels:
-      app: rabbitmq
+      app.kubernetes.io/name: rabbitmq
   ingress:
     - from:
       - podSelector:
@@ -780,7 +780,7 @@ spec:
     - to:
       - podSelector:
           matchLabels:
-              app: rabbitmq
+              app.kubernetes.io/name: rabbitmq
       ports:
       - protocol: TCP
         port: {{ default 5672 .Values.rabbitmq.service.port }}
@@ -795,7 +795,7 @@ spec:
     - Ingress
   podSelector:
    matchLabels:
-      app: rabbitmq
+      app.kubernetes.io/name: rabbitmq
   ingress:
     - from:
       - podSelector:
@@ -820,7 +820,7 @@ spec:
     - to:
       - podSelector:
           matchLabels:
-              app: rabbitmq
+              app.kubernetes.io/name: rabbitmq
       ports:
       - protocol: TCP
         port: {{ default 5672 .Values.rabbitmq.service.port }}
@@ -835,7 +835,7 @@ spec:
     - Ingress
   podSelector:
    matchLabels:
-      app: rabbitmq
+      app.kubernetes.io/name: rabbitmq
   ingress:
     - from:
       - podSelector:
@@ -860,7 +860,7 @@ spec:
     - to:
       - podSelector:
           matchLabels:
-              app: rabbitmq
+              app.kubernetes.io/name: rabbitmq
       ports:
       - protocol: TCP
         port: {{ default 5672 .Values.rabbitmq.service.port }}
@@ -875,7 +875,7 @@ spec:
     - Ingress
   podSelector:
    matchLabels:
-      app: rabbitmq
+      app.kubernetes.io/name: rabbitmq
   ingress:
     - from:
       - podSelector:

--- a/charts/rasa-x/templates/rasa-config-files-configmap.yaml
+++ b/charts/rasa-x/templates/rasa-config-files-configmap.yaml
@@ -35,7 +35,7 @@ data:
     event_broker:
       type: "pika"
       url: "{{ template "rasa-x.rabbitmq.host" . }}"
-      username: "{{ .Values.rabbitmq.rabbitmq.username }}"
+      username: "{{ .Values.rabbitmq.auth.username }}"
       password: ${RABBITMQ_PASSWORD}
       port: {{ default 5672 .Values.rabbitmq.service.port }}
       {{ if or (regexMatch ".*(a|rc)[0-9]+" .Values.rasa.version) (regexMatch "2.*[0-9]+-full" .Values.rasa.version) -}}

--- a/charts/rasa-x/values.schema.json
+++ b/charts/rasa-x/values.schema.json
@@ -9,18 +9,18 @@
             "$id": "#/properties/rabbitmq",
             "type": "object",
             "required": [
-                "rabbitmq"
+                "auth"
             ],
             "properties": {
-                "rabbitmq": {
-                    "$id": "#/properties/rabbitmq/properties/rabbitmq",
+                "auth": {
+                    "$id": "#/properties/rabbitmq/properties/auth",
                     "type": "object",
                     "required": [
                         "password"
                     ],
                     "properties": {
                         "password": {
-                            "$id": "#/properties/rabbitmq/properties/rabbitmq/properties/password",
+                            "$id": "#/properties/rabbitmq/properties/auth/properties/password",
                             "type": "string",
                             "title": "The RabbitMQ password schema",
                             "description": "RabbitMQ password shouldn't contain '#' character - https://www.rabbitmq.com/passwords.html#credential-validation-limitations.",

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -729,14 +729,14 @@ postgresql:
   #   fsGroup: 1001
   #   runAsUser: 1001
 
-# RabbitMQ specific settings (https://hub.helm.sh/charts/bitnami/rabbitmq/6.19.2)
+# RabbitMQ specific settings (https://artifacthub.io/packages/helm/bitnami/rabbitmq/8.26.0)
 rabbitmq:
   # Install should be `true` if the rabbitmq subchart should be used
   install: true
   # Enabled should be `true` if any version of rabbit is used
   enabled: true
-  # rabbitmq settings of the subchart
-  rabbitmq:
+
+  auth:
     # username which is used for the authentication
     username: "user"
     # password which is used for the authentication
@@ -752,7 +752,7 @@ rabbitmq:
   # existingPasswordSecretKey is the key to get the password when an external rabbitmq instance is provided (`install: false`)
   existingPasswordSecretKey: ""
   # # security context for the rabbitmq container (please see the documentation of the subchart)
-  # securityContext:
+  # podSecurityContext:
   #   enabled: true
   #   fsGroup: 1001
   #   runAsUser: 1001

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -702,7 +702,7 @@ separateEventService: "true"
 # If set to 'false', Rasa X will run a database migration service as a subprocess.
 separateDBMigrationService: true
 
-# postgresql specific settings (https://hub.helm.sh/charts/bitnami/postgresql/8.6.13)
+# postgresql specific settings (https://artifacthub.io/packages/helm/bitnami/postgresql/10.15.1)
 postgresql:
   # Install should be `true` if the postgres subchart should be used
   install: true

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -715,7 +715,7 @@ postgresql:
 
   image:
     # tag of PostgreSQL Image
-    tag: "12.8.0"
+    tag: "12.9.0"
 
   # Configure security context for the postgresql init container
   # volumePermissions:
@@ -723,10 +723,12 @@ postgresql:
   #   securityContext:
   #     runAsUser: 0
 
-  ## Configure security context for the rabbitmq container
+  ## Configure security context for the postgresql pod
   # securityContext:
   #   enabled: true
   #   fsGroup: 1001
+  # containerSecurityContext:
+  #   enabled: true
   #   runAsUser: 1001
 
 # RabbitMQ specific settings (https://artifacthub.io/packages/helm/bitnami/rabbitmq/8.26.0)

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -757,27 +757,35 @@ rabbitmq:
   #   fsGroup: 1001
   #   runAsUser: 1001
 
-# redis specific settings (https://hub.helm.sh/charts/bitnami/redis/10.5.14)
+# redis specific settings (https://artifacthub.io/packages/helm/bitnami/redis/15.7.2)
 redis:
   # Install should be `true` if the redis subchart should be used
   install: true
-  # cluster settings for redis (Rasa does currently not support redis sentinels)
-  cluster:
-    # set up a single Redis instance, as `redis-py` does not support clusters (https://github.com/andymccurdy/redis-py#cluster-mode)
-    enabled: false
-  # redisPort: port which should be used to expose redis to the other components
-  redisPort: 6379
-  # existingSecret which should be used for the password instead of putting it in the values file
-  existingSecret: ""
-  # existingSecretPasswordKey is the key to get the password when an external redis instance is provided
-  existingSecretPasswordKey: ""
+  # architecture defines an architecture type used for Redis deployment. Allowed values: standalone or replication (Rasa does currently not support redis sentinels)
+  # set up a single Redis instance, as `redis-py` does not support clusters (https://github.com/andymccurdy/redis-py#cluster-mode)
+  architecture: "standalone"
+  master:
+    service:
+      # port defines Redis master service port
+      port: 6379
+
+    # security context for the redis pod (please see the documentation of the subchart)
+    # podSecurityContext:
+    #  enabled: false
+    #  fsGroup: 1001
+
+    # security context for the redis container(please see the documentation of the subchart)
+    #containerSecurityContext:
+    #  enabled: false
+    #  fsGroup: 1001
+
+  auth:
+    # existingSecret which should be used for the password instead of putting it in the values file
+    existingSecret: ""
+    # existingSecretPasswordKey is the key to get the password when an external redis instance is provided
+    existingSecretPasswordKey: ""
   # existingHost is the host which is used when an external redis instance is provided (`install: false`)
   existingHost: ""
-  # # security context for the redis container (please see the documentation of the subchart)
-  # securityContext:
-  #   enabled: true
-  #   fsGroup: 1001
-  #   runAsUser: 1001
 
 # ingress settings
 ingress:

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -772,7 +772,7 @@ redis:
       port: 6379
 
     # security context for the redis pod (please see the documentation of the subchart)
-    # podSecurityContext:
+    #podSecurityContext:
     #  enabled: false
     #  fsGroup: 1001
 

--- a/examples/openshift-values.yaml
+++ b/examples/openshift-values.yaml
@@ -1,0 +1,31 @@
+# Example values for OpenShift
+securityContext:
+  fsGroup: null
+
+nginx:
+  name: "nginxinc/nginx-unprivileged"
+  tag: "1.19.10"
+
+postgresql:
+  securityContext:
+    enabled: false
+  containerSecurityContext:
+    enabled: false
+
+redis:
+  master:
+    podSecurityContext:
+      enabled: false
+      fsGroup: ""
+    containerSecurityContext:
+      enabled: false
+      runAsUser: "auto"
+  volumePermissions:
+    securityContext:
+      runAsUser: "auto"
+
+rabbitmq:
+  podSecurityContext:
+    enabled: false
+    fsGroup: ""
+    runAsUser: "auto"


### PR DESCRIPTION
Resolves #258 

The rasa-x-helm chart in version 4.0.0 introduces the following breaking changes:

Update chart dependencies to the latest available version, below you can find listed a summary of major changes compared to the previous version used by the rasa-x-helm chart:

* Redis - the chart for Redis is updated to version 15.

  - Credentials parameter are reorganized under the `auth` parameter.
  - The `cluster.enabled` parameter is deprecated in favor of `architecture` parameter that accepts two values: `standalone` and `replication`.
  - `securityContext.*` is deprecated in favor of `XXX.podSecurityContext` and `XXX.containerSecurityContext` (`XXX` can be replaces with `master` or `replica`).
  - `redis.redisPort` is deprecated in favor of `master.service.port` and `replica.service.port`.

  A full list of changes between versions for the Bitnami Redis chart can be found [here](https://artifacthub.io/packages/helm/bitnami/redis).

* RabbitMQ - the chart for RabbitMQ is updated to version 8.

  - `securityContext.*` is deprecated in favor of `podSecurityContext` and `containerSecurityContext`.
  - Authentication parameters were reorganized under the `auth.*` parameter:
    - `rabbitmq.username`, `rabbitmq.password`, and `rabbitmq.erlangCookie` are now `auth.username`, `auth.password`, and `auth.erlangCookie` respectively.

  A full list of changes between versions for the Bitnami RabbitMQ chart can be found [here](https://artifacthub.io/packages/helm/bitnami/rabbitmq).

* RabbitMQ - the chart for PostgreSQL is updated to version 10.

  - Default PostgresSQL version is updated from `12.8.0` to `12.9.0` (a dump/restore is not required for those running 12.X)
  - The term `master` has been replaced with `primary` and `slave` with `readReplicas` throughout the chart. Role names have changed from `master` and `slave` to `primary` and `read`.

  A full list of changes between versions for the Bitnami RabbitMQ chart can be found [here](https://artifacthub.io/packages/helm/bitnami/postgresql).