### PR TITLE
doc: Update the default url for external rasa chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,14 +93,14 @@ The following configuration disables the `rasa-production` deployment and uses a
         enabled: true
 
         # URL address of external Rasa OSS deployment
-        url: "https://rasa-bot.external.deployment.domain.com"
+        url: "https://rasa.external.deployment.domain.com"
 ```
 
 Now you can apply your changes by using the `helm upgrade` command.
 
 > **_NOTE:_** Any Rasa Open Source server can stream events to Rasa X/Enterprise using an [event broker](https://rasa.com/docs/rasa/event-brokers). Both Rasa and Rasa X/Enterprise will need to refer to the same event broker.
 
-You can use the rasa-bot helm chart to deploy Rasa OSS. Visit [the rasa chart docs](https://github.com/RasaHQ/helm-charts/tree/main/charts/rasa) to learn more.
+You can use the rasa helm chart to deploy Rasa OSS. Visit [the rasa chart docs](https://github.com/RasaHQ/helm-charts/tree/main/charts/rasa) to learn more.
 
 ## Configuration
 

--- a/charts/rasa-x/templates/_rasa.tpl
+++ b/charts/rasa-x/templates/_rasa.tpl
@@ -1,9 +1,9 @@
 {{/* Return Rasa OSS URL - the production environment */}}
 {{- define "rasa.production.url" -}}
-{{- if and (not .Values.rasa.versions.rasaProduction.enabled) .Values.rasa.versions.rasaProduction.external.enabled (not (empty .Values.rasa.versions.rasaProduction.external.url)) (not ((index .Values "rasa-bot").subchart)) }}
+{{- if and (not .Values.rasa.versions.rasaProduction.enabled) .Values.rasa.versions.rasaProduction.external.enabled (not (empty .Values.rasa.versions.rasaProduction.external.url)) (not ((index .Values "rasa").subchart)) }}
 {{- print .Values.rasa.versions.rasaProduction.external.url }}
-{{- else if and (not .Values.rasa.versions.rasaProduction.enabled) (index .Values "rasa-bot").subchart }}
-{{- printf "%s://%s-%s.%s.svc:%d" (index .Values "rasa-bot").applicationSettings.scheme (include "rasa-x.fullname" .) "rasa-bot" .Release.Namespace ((index .Values "rasa-bot").applicationSettings.port | int) }}
+{{- else if and (not .Values.rasa.versions.rasaProduction.enabled) (index .Values "rasa").subchart }}
+{{- printf "%s://%s-%s.%s.svc:%d" (index .Values "rasa").applicationSettings.scheme (include "rasa-x.fullname" .) "rasa" .Release.Namespace ((index .Values "rasa").applicationSettings.port | int) }}
 {{- else }}
 {{- printf "%s://%s-%s.%s.svc:%d" .Values.rasa.scheme (include "rasa-x.fullname" .) .Values.rasa.versions.rasaProduction.serviceName .Release.Namespace (.Values.rasa.port | int) }}
 {{- end }}
@@ -11,7 +11,7 @@
 
 {{/* Return Rasa OSS URL - the worker environment */}}
 {{- define "rasa.worker.url" -}}
-{{- if and (not .Values.rasa.versions.rasaWorker.enabled) .Values.rasa.versions.rasaWorker.external.enabled (not (empty .Values.rasa.versions.rasaWorker.external.url)) (not ((index .Values "rasa-bot").subchart)) }}
+{{- if and (not .Values.rasa.versions.rasaWorker.enabled) .Values.rasa.versions.rasaWorker.external.enabled (not (empty .Values.rasa.versions.rasaWorker.external.url)) (not ((index .Values "rasa").subchart)) }}
 {{- print .Values.rasa.versions.rasaWorker.external.url }}
 {{- else }}
 {{- printf "%s://%s-%s.%s.svc:%d" .Values.rasa.scheme (include "rasa-x.fullname" .) .Values.rasa.versions.rasaWorker.serviceName .Release.Namespace (.Values.rasa.port | int) }}

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -222,8 +222,8 @@ rasa:
         # enable external Rasa OSS
         enabled: false
 
-        # host of external Rasa OSS deployment
-        host: "http://rasa-bot"
+        # url of external Rasa OSS deployment
+        url: "http://rasa:5005"
 
       # nodeSelector to specify which node the pods should run on
       # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -150,7 +150,7 @@ rasa:
   additionalChannelCredentials: {}
     # rest:
     # facebook:
-    #   verify: "rasa-bot"
+    #   verify: "rasa"
     #   secret: "3e34709d01ea89032asdebfe5a74518"
     #   page-access-token: "EAAbHPa7H9rEBAAuFk4Q3gPKbDedQnx4djJJ1JmQ7CAqO4iJKrQcNT0wtD"
   # input channels


### PR DESCRIPTION
- Set the default url for external rasa chart to `http://rasa:5005`, which is the default url if the Rasa helm chart is deployed in the same namespace as the Rasa X helm chart.
- `s/rasa-bot/rasa/g`