### PR TITLE
fix: Don't create ingress for Rasa OSS if deployment is disabled

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "3.1.2"
+version: "3.1.3"
 
 appVersion: "1.0.1"
 
@@ -42,4 +42,4 @@ annotations:
   # See: https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations
   artifacthub.io/changes: |
     - kind: fixed
-      description: Change incorrect field name from `rasa.versions.rasaXXX.external.host` to `rasa.versions.rasaXXX.external.url` in the values file.
+      description: Don't create an ingress resource for Rasa OSS if Rasa OSS deployment is disabled.

--- a/charts/rasa-x/templates/rasa-open-source-api-ingress.yaml
+++ b/charts/rasa-x/templates/rasa-open-source-api-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ingress.enabled (not .Values.nginx.enabled) -}}
+{{- if and .Values.ingress.enabled (not .Values.nginx.enabled) .Values.rasa.versions.rasaProduction.enabled -}}
 {{- $fullName := include "rasa-x.fullname" . -}}
 {{- if semverCompare ">=1.19" .Capabilities.KubeVersion.Version -}}
 apiVersion: networking.k8s.io/v1

--- a/charts/rasa-x/templates/rasa-open-source-channels-ingress.yaml
+++ b/charts/rasa-x/templates/rasa-open-source-channels-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ingress.enabled (not .Values.nginx.enabled) -}}
+{{- if and .Values.ingress.enabled (not .Values.nginx.enabled) .Values.rasa.versions.rasaProduction.enabled -}}
 {{- $fullName := include "rasa-x.fullname" . -}}
 {{- if semverCompare ">=1.19" .Capabilities.KubeVersion.Version -}}
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
- Don't create an ingress resource for Rasa OSS if Rasa OSS deployment is disabled