### PR TITLE
feat: Add support for overriding the `RASA_X_HOST` variable

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "4.1.0"
+version: "4.2.0"
 
 appVersion: "1.0.1"
 
@@ -42,4 +42,4 @@ annotations:
   # See: https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations
   artifacthub.io/changes: |
     - kind: added
-      description: Add support for ingressClassName field
+      description: Add support for changing value of the RASA_X_HOST environment variable defined in the rasa-x deployment

--- a/charts/rasa-x/templates/rasa-x-deployment.yaml
+++ b/charts/rasa-x/templates/rasa-x-deployment.yaml
@@ -91,7 +91,11 @@ spec:
         - name: "LOCAL_MODE" # This variable doesn't do anything anymore in Rasa X 0.28 and later
           value: "false"
         - name: "RASA_X_HOST"
+          {{- if empty .Values.rasax.overrideHost }}
           value: {{ .Values.rasax.scheme }}://{{ include "rasa-x.host" . }}.{{ .Release.Namespace }}.svc:{{ .Values.rasax.port }}
+          {{- else }}
+          value: {{ .Values.rasax.overrideHost }}
+          {{- end }}
         - name: "RASA_MODEL_DIR"
           value: "/app/models"
         - name: "RUN_EVENT_CONSUMER_AS_SEPARATE_SERVICE"

--- a/charts/rasa-x/templates/rasa-x-service.yaml
+++ b/charts/rasa-x/templates/rasa-x-service.yaml
@@ -10,6 +10,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
 {{- end }}
 spec:
+  type: {{ .Values.rasax.service.type | quote }}
   ports:
   - port: {{ .Values.rasax.port }}
     targetPort: http

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -102,6 +102,8 @@ rasax:
   service:
     # annotations for the service
     annotations: {}
+    # type sets type of the service
+    type: "ClusterIP"
 
   # podLabels adds additional pod labels
   # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
@@ -113,6 +115,9 @@ rasax:
   # dnsPolicy specifies Pod's DNS policy
   # ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
   dnsPolicy: ""
+
+  # overrideHost overrides values of the RASA_X_HOST variable defined for the deployment
+  overrideHost: ""
 
 # rasa: Settings common for all Rasa containers
 # deprecated: the Rasa OSS deployment is deprecated and will be removed in the feature


### PR DESCRIPTION
-  Add support for overriding the `RASA_X_HOST` variable defined in the rasa-x deployment.