### PR TITLE
fix: Set the empty table as a default value for the rasax.hostAliases field

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "4.3.0"
+version: "4.3.1"
 
 appVersion: "1.0.1"
 
@@ -41,5 +41,5 @@ dependencies:
 annotations:
   # See: https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations
   artifacthub.io/changes: |
-    - kind: added
-      description: Add support for setting hostAliases for the rasa-x deployment
+    - kind: fixed
+      description: Set empty table as a default value for the rasax.hostAliases field

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -118,7 +118,7 @@ rasax:
 
   # hostAliases defines additional entries to the hosts file.
   # ref: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/#adding-additional-entries-with-hostaliases
-  hostAliases: {}
+  hostAliases: []
 
   # overrideHost overrides values of the RASA_X_HOST variable defined for the deployment
   overrideHost: ""


### PR DESCRIPTION
-  Set the empty table as a default value for the rasax.hostAliases field