### PR TITLE
fix: Don't include DB envs if the `postgresql.install` is set to `false`

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "4.3.1"
+version: "4.3.2"
 
 appVersion: "1.0.1"
 
@@ -42,4 +42,4 @@ annotations:
   # See: https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations
   artifacthub.io/changes: |
     - kind: fixed
-      description: Set empty table as a default value for the rasax.hostAliases field
+      description: Don't include DB envs with credentials if the postgresql.install is set to false

--- a/charts/rasa-x/templates/_postgresql.tpl
+++ b/charts/rasa-x/templates/_postgresql.tpl
@@ -64,6 +64,7 @@ postgresql-password
 Return the common database env variables.
 */}}
 {{- define "rasa-x.psql.envs" -}}
+{{- if or .Values.postgresql.install (and (not .Values.postgresql.install) .Values.postgresql.existingHost) -}}
 - name: "DB_USER"
   value: "{{ template "rasa-x.psql.username" . }}"
 - name: "DB_HOST"
@@ -77,4 +78,5 @@ Return the common database env variables.
     secretKeyRef:
       name: {{ template "rasa-x.psql.password.secret" . }}
       key: {{ template "rasa-x.psql.password.key" . }}
+{{- end -}}
 {{- end -}}

--- a/charts/rasa-x/templates/rasa-deployments.yaml
+++ b/charts/rasa-x/templates/rasa-deployments.yaml
@@ -100,11 +100,13 @@ spec:
         {{ end }}
         - name: "MPLCONFIGDIR"
           value: "/tmp/.matplotlib"
+        {{- if or $.Values.postgresql.install (and (not $.Values.postgresql.install) $.Values.postgresql.existingHost) }}
         - name: "DB_PASSWORD"
           valueFrom:
             secretKeyRef:
               name: {{ template "rasa-x.psql.password.secret" $ }}
               key: {{ template "rasa-x.psql.password.key" $ }}
+        {{- end }}
         - name: "DB_DATABASE"
           value: {{ .trackerDatabase }}
         - name: "RASA_X_TOKEN"


### PR DESCRIPTION
- Don't include DB envs if the `postgresql.install` is set to false