### PR TITLE
fix: switch to base32 encoding

### DIFF
--- a/charts/rasa-x/templates/rasa-secret.yaml
+++ b/charts/rasa-x/templates/rasa-secret.yaml
@@ -7,9 +7,9 @@ metadata:
   name: {{ template "rasa-x.secret" . }}
 type: "Opaque"
 data:
-  rasaToken: {{ .Values.rasa.token | b64enc | quote }}
-  rasaXToken: {{ .Values.rasax.token | b64enc | quote }}
-  passwordSalt: {{ .Values.rasax.passwordSalt | b64enc | quote }}
+  rasaToken: {{ .Values.rasa.token | b32enc | quote }}
+  rasaXToken: {{ .Values.rasax.token | b32enc | quote }}
+  passwordSalt: {{ .Values.rasax.passwordSalt | b32enc | quote }}
   jwtSecret: {{ .Values.rasax.jwtSecret | b64enc | quote }}
   initialPassword: {{ .Values.rasax.initialUser.password | b64enc | quote }}
 {{ end }}


### PR DESCRIPTION
Base64 uses chars that can break in URLs, `+` and `/`