### PR TITLE
feat: add namespaceSelector to egress rule for allow-dns-access

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "4.3.4"
+version: "4.4.0"
 
 appVersion: "1.0.1"
 
@@ -42,4 +42,4 @@ annotations:
   # See: https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations
   artifacthub.io/changes: |
     - kind: changed
-      description: Use new endpoint instead of deprecated one for RASA_MODEL_SERVER default value
+      description: Add namespaceSelector to egress rule for allow-dns-access

--- a/charts/rasa-x/templates/network-policy.yaml
+++ b/charts/rasa-x/templates/network-policy.yaml
@@ -16,6 +16,10 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+    to:
+    - namespaceSelector:
+        matchLabels:
+          name: kube-system
 {{ if .Values.rasa.versions.rasaProduction.enabled -}}
 ---
 apiVersion: {{ template "networkPolicy.apiVersion" . }}


### PR DESCRIPTION
This PR adds ensures that egress for allow-dns-access is restricted to the `kube-system` namespace.