### PR TITLE
Fix - Unable to locate user defined redis secret 

### DIFF
--- a/charts/rasa-x/templates/_redis.tpl
+++ b/charts/rasa-x/templates/_redis.tpl
@@ -20,18 +20,18 @@ Return the redis host.
 Return the redis password secret name.
 */}}
 {{- define "rasa-x.redis.password.secret" -}}
-{{- default (include "redis.fullname" .) .Values.redis.existingSecret | quote -}}
+{{- default (include "redis.fullname" .) .Values.redis.auth.existingSecret | quote -}}
 {{- end -}}
 
 {{/*
 Return the redis password secret key.
 */}}
 {{- define "rasa-x.redis.password.key" -}}
-  {{- if and .Values.redis.install .Values.redis.existingSecret -}}
-    {{- coalesce .Values.redis.existingSecretPasswordKey "redis-password" | quote -}}
+  {{- if and .Values.redis.install .Values.redis.auth.existingSecret -}}
+    {{- coalesce .Values.redis.auth.existingSecretPasswordKey "redis-password" | quote -}}
   {{- else if .Values.redis.install -}}
     "redis-password"
   {{- else -}}
-    {{- default "redis-password" .Values.redis.existingSecretPasswordKey | quote -}}
+    {{- default "redis-password" .Values.redis.auth.existingSecretPasswordKey | quote -}}
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
According to the [https://github.com/RasaHQ/rasa-x-helm/blob/99f8f5789948a350f8585527c92c3e767268e77c/charts/rasa-x/values.yaml#L813](values.yaml) file, user should define _existingSecret_ and _existingSecretPasswordKey_ under _redis.auth_  for connecting to external redis cluster.

But after deployment Rasa pods failed to figure out the secret name due to this bug and throwing this error
`Error: secret "rasa-x-1647107101-redis" not found`




