### PR TITLE
feat: Add support for defining an IP block for egress network policies

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "4.4.1"
+version: "4.5.0"
 
 appVersion: "1.0.1"
 
@@ -41,5 +41,5 @@ dependencies:
 annotations:
   # See: https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bugfix for external redis with credentials
+    - kind: added
+      description: Add support for defining target for the egress-from-rabbitmq-to-k8s-api and egress-from-rasa-x-to-https network policies.

--- a/charts/rasa-x/templates/network-policy.yaml
+++ b/charts/rasa-x/templates/network-policy.yaml
@@ -852,6 +852,10 @@ spec:
         port: 8443
       - protocol: TCP
         port: 443
+    {{- if .Values.networkPolicy.apiCIDR }}
+    to:
+      {{- toYaml .Values.networkPolicy.apiCIDR | nindent 6 }}
+    {{- end }}
 ---
 apiVersion: {{ template "networkPolicy.apiVersion" . }}
 kind: NetworkPolicy

--- a/charts/rasa-x/templates/network-policy.yaml
+++ b/charts/rasa-x/templates/network-policy.yaml
@@ -852,9 +852,9 @@ spec:
         port: 8443
       - protocol: TCP
         port: 443
-    {{- if .Values.networkPolicy.apiCIDR }}
+    {{- if .Values.networkPolicy.egress.apiCIDR }}
     to:
-      {{- toYaml .Values.networkPolicy.apiCIDR | nindent 6 }}
+      {{- toYaml .Values.networkPolicy.egress.apiCIDR | nindent 6 }}
     {{- end }}
 ---
 apiVersion: {{ template "networkPolicy.apiVersion" . }}
@@ -1157,4 +1157,8 @@ spec:
     - ports:
       - protocol: TCP
         port: 443
+    {{- if .Values.networkPolicy.egress.rasaxToHttpsCIDR }}
+      to:
+        {{- toYaml .Values.networkPolicy.egress.rasaxToHttpsCIDR | nindent 6 }}
+    {{- end }}
 {{- end }}

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -856,10 +856,16 @@ networkPolicy:
   #  - ipBlock:
   #      cidr: 0.0.0.0/0
 
-  # Allow for adding the specific k8s api IP/CIDR for the egress-from-rabbitmq-to-k8s-api NetworkPolicy
-  apiCIDR: null
-  #  - ipBlock:
-  #      cidr: 10.0.0.0/8
+  egress:
+    # Allow for adding the specific k8s api IP/CIDR for the egress-from-rabbitmq-to-k8s-api NetworkPolicy
+    apiCIDR: []
+    #- ipBlock:
+    #    cidr: 10.0.0.0/8
+
+    # Allow for adding the specific IP/CIDR for the egress-from-rasa-x-to-https NetworkPolicy
+    rasaxToHttpsCIDR: []
+    #- ipBlock:
+    #    cidr: 11.0.0.0/8
 
 # images: Settings for the images
 images:

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -856,6 +856,11 @@ networkPolicy:
   #  - ipBlock:
   #      cidr: 0.0.0.0/0
 
+  # Allow for adding the specific k8s api IP/CIDR for the egress-from-rabbitmq-to-k8s-api NetworkPolicy
+  apiCIDR: null
+  #  - ipBlock:
+  #      cidr: 10.0.0.0/8
+
 # images: Settings for the images
 images:
   # pullPolicy to use when deploying images


### PR DESCRIPTION
Some environments have OPA policies enforcing that there is a 'to' specified for any egress NetworkPolicy. 

This update adds new values (`networkPolicy.egress.apiCIDR` and `networkPolicy.egress.rasaxToHttpsCIDR` ) so that an address can be set.