### PR TITLE
remove a - from line 167 which caused a missing netpol

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "4.5.1"
+version: "4.5.2"
 
 appVersion: "1.0.1"
 
@@ -42,4 +42,4 @@ annotations:
   # See: https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations
   artifacthub.io/changes: |
     - kind: fix
-      description: Update the default value for nodeCIDR in values.yaml to address the table/non-table warning
+      description: Due to a missing newline a network policy was missing upon deployment

--- a/charts/rasa-x/templates/network-policy.yaml
+++ b/charts/rasa-x/templates/network-policy.yaml
@@ -164,7 +164,7 @@ spec:
       ports:
       - protocol: TCP
         port: {{ .Values.rasa.port }}
-{{- if .Values.networkPolicy.nodeCIDR -}}
+{{- if .Values.networkPolicy.nodeCIDR }}
 ---
 apiVersion: {{ template "networkPolicy.apiVersion" . }}
 kind: NetworkPolicy


### PR DESCRIPTION
The extra '-' was causing the egress-from-rasa-x-to-rasa-production not to get deployed due to a missing newline