### PR TITLE
bump tag version for duckling

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "4.5.4"
+version: "4.5.5"
 
 appVersion: "1.0.1"
 
@@ -41,5 +41,5 @@ dependencies:
 annotations:
   # See: https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations
   artifacthub.io/changes: |
-    - kind: fix
-      description: Remove '$' from the password validation schema for RabbitMQ
+    - kind: changed
+      description: Bump duckling version to 0.2.0.2

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -635,7 +635,7 @@ duckling:
   # name of the Duckling image to use
   name: "rasa/duckling"
   # tag refers to the duckling image tag
-  tag: "0.1.6.3"
+  tag: "0.2.0.2"
   # replicaCount of duckling containers to run
   replicaCount: 1
   # port on which duckling should run


### PR DESCRIPTION
The default duckling image tag of 0.1.6.3 needs to be bumped to the latest (0.2.0.2)