### PR TITLE
[BT-175] Show environments URLs after helm run

### DIFF
--- a/charts/rasa-x/templates/NOTES.txt
+++ b/charts/rasa-x/templates/NOTES.txt
@@ -6,5 +6,19 @@ Creating a Rasa Enterprise user: go to the terminal of the `rasa-x` pod and then
   You can then log in using these credentials.
 {{- end }}
 
+You have to add a deployment and training environment manually
+{{ if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  - http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/environments
+{{- end }}
+{{ end }}
+
+{{- if eq (include "rasa-x.production.env.used" .) "true" }}
+Rasa production environment: {{ include "rasa.production.url" .}}
+{{- end }}
+{{- if eq (include "rasa-x.worker.env.used" .) "true"  }}
+Rasa worker environment: {{ include "rasa.worker.url" .}}
+{{- end }}
+
 Check out the Rasa Enterprise docs here for more help:
 https://rasa.com/docs/rasa-enterprise/


### PR DESCRIPTION
Show environments in the output to help users with the initial setup.

```
You have to add a deployment and training environment manually.

  - http://example.com/environments
  - http://example.net/environments

Rasa production environment: http://ee-rasa-x-rasa-production.rasa-ee.svc:5005
Rasa worker environment: http://ee-rasa-x-rasa-worker.rasa-ee.svc:5005
```

[BT-175](https://rasahq.atlassian.net/browse/BT-175)