### PR TITLE
Update and Pin Third Party Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
 
     # See https://github.com/helm/chart-releaser-action/issues/6
     - name: Install Helm
-      uses: azure/setup-helm@v1
+      uses: azure/setup-helm@f382f75448129b3be48f8121b9857be18d815a82
       with:
         version: v3.10.0
 

--- a/.github/workflows/update_rasa_x_version.yml
+++ b/.github/workflows/update_rasa_x_version.yml
@@ -66,7 +66,7 @@ jobs:
           echo "::set-output name=new_branch::bump-rasa-x-version-to-${LATEST_RASA_X_MINOR}-${GITHUB_SHA:0:7}"
 
       - name: Create new branch 🐣
-        uses: peterjgrainger/action-create-branch@v2.0.1
+        uses: peterjgrainger/action-create-branch@08259812c8ebdbf1973747f9297e332fa078d3c1
         if: env.CREATE_UPDATE_PR == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -89,7 +89,7 @@ jobs:
           git push origin ${{ steps.get-branch-name.outputs.new_branch }}
 
       - name: Open pull request ☄️
-        uses: repo-sync/pull-request@v2
+        uses: repo-sync/pull-request@1b6c62644f972d1a4cf98835ed1efe728d7497a8
         if: env.CREATE_UPDATE_PR == 'true'
         with:
           github_token:  ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I noticed yesterday that we use some third-party actions here that aren't pinned to a specific SHA as we do in other repos. This fixes that and also updates actions that haven't been touched in a while to fix some vulnerabilities and also stay ahead of Github's `set-output` deprecation.

- azure/setup-helm: from v1 to v3.4. No breaking changes from their release notes.
- peterjgrainger/action-create-branch: from v2.0.1 to v2.4. No breaking changes from their release notes.
- repo-sync/pull-request: pinned from v2 to v2.9 explicitly. 