### PR TITLE
feat: add enable_selective_domain in action_endpoint

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "4.5.13"
+version: "4.5.14"
 
 appVersion: "1.2.2"
 
@@ -41,5 +41,5 @@ dependencies:
 annotations:
   # See: https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Too much whitespace removal in lock_store configmap
+    - kind: added
+      description: Added support for enable_selective_domain in endpoints.yml

--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -41,10 +41,5 @@ dependencies:
 annotations:
   # See: https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations
   artifacthub.io/changes: |
-<<<<<<< HEAD
     - kind: added
       description: Added support for enable_selective_domain in endpoints.yml
-=======
-    - kind: fixed
-      description: Refer to Rasa-hosted location for the sub-charts
->>>>>>> main

--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "4.5.12"
+version: "4.5.13"
 
 appVersion: "1.2.2"
 

--- a/charts/rasa-x/templates/rasa-config-files-configmap.yaml
+++ b/charts/rasa-x/templates/rasa-config-files-configmap.yaml
@@ -55,6 +55,7 @@ data:
     action_endpoint:
       url: {{ if .Values.app.existingUrl }}"{{ .Values.app.existingUrl }}"{{ else }}"{{ .Values.app.scheme }}://{{ include "rasa-x.fullname" . }}-app.{{ .Release.Namespace }}.svc:{{ template "rasa-x.custom-actions.port" . }}{{ .Values.app.endpoints.actionEndpointUrl }}"{{ end }}
       token:  ""
+      enable_selective_domain: {{ .Values.rasa.enable_selective_domain }}
     {{- if $.Values.redis.install }}
     lock_store:
       {{- if $.Values.rasa.rasaPlus.enabled }}

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -173,6 +173,8 @@ rasa:
     query: {}
     #  driver: my-driver
     #  sslmode: require
+  # selective domain when enabled sends domain only configured for particular actions. see docs:
+  enable_selective_domain: false
   # Jaeger Sidecar
   jaegerSidecar: "false"
   livenessProbe:


### PR DESCRIPTION
This update is based on the latest patch for Rasa OSS for `enable_selective_domain` in the action_endpoint. This change meant that we need to update our configMap so we can fetch this boolean value from the Values.yml file..

It is defaulted to False which means all Rasa server <--> Action Server communication will include the domain file however with enable_selective_domain set to `true`, only actions that requires a domain file will receive the domain file instead of all of them. This massively improves the performance for the communication between the two services. 