### PR TITLE
Fix Bitnami removing charts from their index

### DIFF
--- a/charts/rasa-x/Chart.lock
+++ b/charts/rasa-x/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://europe-west3-docker.pkg.dev/rasa-releases/rasa-x-helm
   version: 10.15.1
 - name: redis
-  repository: https://charts.bitnami.com/bitnami
-  version: 15.7.4
+  repository: oci://europe-west3-docker.pkg.dev/rasa-releases/rasa-x-helm
+  version: 15.7.2
 - name: rabbitmq
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://europe-west3-docker.pkg.dev/rasa-releases/rasa-x-helm
   version: 8.26.0
-digest: sha256:e5e68596ad301c5f6b26e912c570bd99cbf603f88b60d5c416f4c92a3f8b82ec
-generated: "2022-01-12T13:44:45.71615+01:00"
+digest: sha256:fb3cb00f944a6a9be69106930a9bbe82f42d64ea4360ea08aa95655ac3235ea7
+generated: "2023-02-15T11:35:45.589237Z"

--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -25,17 +25,17 @@ maintainers:
 dependencies:
 - name: postgresql
   version: ~10.15.1
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://europe-west3-docker.pkg.dev/rasa-releases/rasa-x-helm
   condition: postgresql.install
 
 - name: redis
   version: ~15.7.2
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://europe-west3-docker.pkg.dev/rasa-releases/rasa-x-helm
   condition: redis.install
 
 - name: rabbitmq
   version: ~8.26.0
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://europe-west3-docker.pkg.dev/rasa-releases/rasa-x-helm
   condition: rabbitmq.install
 
 annotations:

--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "4.5.12"
+version: "4.5.13"
 
 appVersion: "1.2.2"
 
@@ -42,4 +42,4 @@ annotations:
   # See: https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations
   artifacthub.io/changes: |
     - kind: fixed
-      description: Too much whitespace removal in lock_store configmap
+      description: Refer to Rasa-hosted location for the sub-charts


### PR DESCRIPTION
- Reuploaded Bitnami charts to Rasa-hosted Helm repo
- Swap repos to the Rasa ones

I think this does increase the version of Helm required to 3.8+ to support OCI repos.