### PR TITLE
Update Helm Release components

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,13 +23,13 @@ jobs:
     - name: Install Helm
       uses: azure/setup-helm@v1
       with:
-        version: v3.10.0
+        version: v3.11.1
 
     - name: Add dependency chart repos
       run: |
         helm repo add bitnami https://charts.bitnami.com/bitnami
 
     - name: Run chart-releaser
-      uses: helm/chart-releaser-action@c25b74a986eb925b398320414b576227f375f946  # v1.2.1
+      uses: helm/chart-releaser-action@be16258da8010256c6e82849661221415f031968
       env:
         CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Update the version of Helm and the Helm release action to resolve release failures since we switched to use OCI repos.