### PR TITLE
Model server param

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 
 ### Linux ###
 *~
+**/*.swp
 
 # temporary files which can be created if a process still has a handle open of a
 # deleted file
@@ -141,6 +142,7 @@ fabric.properties
 
 ### VisualStudioCode ###
 .vscode/*
+**/.dccache
 !.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json

--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "4.5.16"
+version: "4.5.17"
 
 appVersion: "1.2.2"
 
@@ -42,4 +42,6 @@ annotations:
   # See: https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations
   artifacthub.io/changes: |
     - kind: added
-      description: Added support to disable adding models to endpoints.yml
+      description: Added support for defining a custom model server
+    - kind: added
+      description: Provide support for disabling nginx-specific annotations on ingress and added finer granularity for annotations on the two open-source ingress objects

--- a/charts/rasa-x/templates/rasa-config-files-configmap.yaml
+++ b/charts/rasa-x/templates/rasa-config-files-configmap.yaml
@@ -14,7 +14,11 @@ data:
   rasa-endpoints: |
   {{- if not $.Values.rasa.disableEndpointsModelServer }}
     models:
+    {{- if $.Values.rasa.modelServerEnv }}
+      url: ${ {{- $.Values.rasa.modelServerEnv -}} }
+    {{- else }}
       url: ${RASA_MODEL_SERVER}
+    {{- end }}
       token: ${RASA_X_TOKEN}
       wait_time_between_pulls: 10
   {{- end }}

--- a/charts/rasa-x/templates/rasa-config-files-configmap.yaml
+++ b/charts/rasa-x/templates/rasa-config-files-configmap.yaml
@@ -14,8 +14,8 @@ data:
   rasa-endpoints: |
   {{- if not $.Values.rasa.disableEndpointsModelServer }}
     models:
-    {{- if $.Values.rasa.modelServerEnv }}
-      url: ${ {{- $.Values.rasa.modelServerEnv -}} }
+    {{- if $.Values.rasa.customModelServer }}
+      url: ${CUSTOM_MODEL_SERVER}
     {{- else }}
       url: ${RASA_MODEL_SERVER}
     {{- end }}

--- a/charts/rasa-x/templates/rasa-open-source-api-ingress.yaml
+++ b/charts/rasa-x/templates/rasa-open-source-api-ingress.yaml
@@ -13,11 +13,16 @@ metadata:
   labels:
     {{- include "rasa-x.labels" . | nindent 4 }}
   annotations:
+    {{- if eq .Values.ingress.ingressType "nginx" }}
     nginx.ingress.kubernetes.io/rewrite-target: /$1
-  {{- with .Values.ingress.annotations }}
+    {{- end -}}
+  {{- with .Values.ingress.annotations -}}
+    {{- toYaml . | nindent 4 }}
+  {{- end -}}
+  {{- with .Values.ingress.annotationsRasa }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- with .Values.ingress.annotationsRasa }}
+  {{- with .Values.ingress.annotationsRasaApi }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
@@ -46,7 +51,11 @@ spec:
             name: {{ $fullName }}-{{ $.Values.rasa.versions.rasaProduction.serviceName }}
             port:
               number: {{ $.Values.rasa.port }}
+        {{ if eq $.Values.ingress.ingressType "nginx" -}}
         path: /core/(.*)
+        {{ else -}}
+        path: /core
+        {{ end -}}
         pathType: Prefix
     {{- end }}
 {{- else -}}
@@ -57,7 +66,11 @@ spec:
       - backend:
           serviceName: {{ $fullName }}-{{ $.Values.rasa.versions.rasaProduction.serviceName }}
           servicePort: {{ $.Values.rasa.port }}
+        {{ if eq $.Values.ingress.ingressType "nginx" -}}
         path: /core/(.*)
+        {{ else -}}
+        path: /core
+        {{ end -}}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/rasa-x/templates/rasa-open-source-channels-ingress.yaml
+++ b/charts/rasa-x/templates/rasa-open-source-channels-ingress.yaml
@@ -19,6 +19,9 @@ metadata:
   {{- with .Values.ingress.annotationsRasa }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.ingress.annotationsRasaChannels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
 {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName | quote }}

--- a/charts/rasa-x/templates/rasa-x-ingress.yaml
+++ b/charts/rasa-x/templates/rasa-x-ingress.yaml
@@ -14,12 +14,10 @@ metadata:
   labels:
     {{- include "rasa-x.labels" . | nindent 4 }}
   annotations:
-  {{- with .Values.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-  {{- with .Values.ingress.annotationsRasaX }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  {{- if eq .Values.ingress.ingressType "nginx" }}
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       if ($arg_environment = "") {
           rewrite ^/api/chat$ /core/webhooks/rasa/webhook last;
@@ -29,6 +27,13 @@ metadata:
       }
     nginx.ingress.kubernetes.io/server-snippet: |
       add_header X-Robots-Tag none;
+  {{- end -}}
+  {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.ingress.annotationsRasaX }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
 {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName | quote }}

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -860,6 +860,10 @@ ingress:
   # Note that if `nginx.enabled` is `true` the `nginx` image is used as reverse proxy.
   # In order to use nginx ingress you have to set `nginx.enabled=false`.
   enabled: false
+  # By default the chart will use nginx ingress specific annotations
+  # for URI rewriting. If different annotations are required change
+  # this value from its default
+  ingressType: nginx
   # enable and set ingressClassName field in the ingress object.
   ingressClassName: ""
   # annotations for the ingress - annotations are applied for the rasa and rasax ingresses
@@ -869,10 +873,11 @@ ingress:
   # annotationsRasa is extra annotations for the rasa nginx ingress
   annotationsRasa: {}
   # annotationsRasaX is extra annotations for the Rasa Enterprise nginx ingress
-  annotationsRasaX:
-    nginx.ingress.kubernetes.io/proxy-body-size: "0"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+  annotationsRasaX: {}
+  # annotationsRasaChannels is extra annotations that apply only to the open-source-channels ingress object
+  annotationsRasaChannels: {}
+  # annotationsRasaApi is extra annotations that apply only to the open-source-api ingress object
+  annotationsRasaApi: {}
   # hosts for this ingress
   hosts:
     - host: rasa-x.example.com

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -195,23 +195,23 @@ rasa:
   lockStoreDatabase: "1"
   # cacheDatabase is the database in redis which Rasa Enterprise uses to store cached values
   cacheDatabase: "2"
-  # to fully override the model server URL define the env variable that should be referenced
-  # with modelServerEnv; make certain to define this env variable in the extraEnvs section
-  modelServerEnv: ""
+  # to fully override the model server URL set customModelServer to true AND define
+  # CUSTOM_MODEL_SERVER in the extraEnvs section
+  customModelServer: "false"
   # extraEnvs are environment variables which can be added to the Rasa deployment
   extraEnvs: []
-    # example which sets env variables in each Rasa Open Source service from a separate k8s secret
-    # - name: "TWILIO_ACCOUNT_SID"
+    # examples for defining the CUSTOM_MODEL_SERVER environment variable when
+    # customModelServer is set to true; the first pulls the value from a secret
+    # should the URL contain credentials, the second is when protection is not
+    # required
+    # - name: "CUSTOM_MODEL_SERVER"
     #   valueFrom:
     #     secretKeyRef:
-    #       name: twilio-auth
-    #       key: twilio_account_sid
-    # - name: TWILIO_AUTH_TOKEN
-    #   valueFrom:
-    #     secretKeyRef:
-    #       name: twilio-auth
-    #       key: twilio_auth_token
-
+    #       name: model-server
+    #       key: url
+    # - name: "CUSTOM_MODEL_SERVER"
+    #   value: "https://your-model-server/models/latest-model.tar.gz"
+  
   # tolerations can be used to control the pod to node assignment
   # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   tolerations: []

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -195,6 +195,9 @@ rasa:
   lockStoreDatabase: "1"
   # cacheDatabase is the database in redis which Rasa Enterprise uses to store cached values
   cacheDatabase: "2"
+  # to fully override the model server URL define the env variable that should be referenced
+  # with modelServerEnv; make certain to define this env variable in the extraEnvs section
+  modelServerEnv: ""
   # extraEnvs are environment variables which can be added to the Rasa deployment
   extraEnvs: []
     # example which sets env variables in each Rasa Open Source service from a separate k8s secret


### PR DESCRIPTION
Improvements:
Ability to provide a custom model server location
If the ingress is not nginx, provide the ability for removal of nginx-related annotations
Additional granularity for ingress annotations on the api and channels ingress objects