### PR TITLE
feat(nginx): allow to specify run path for nginx.pid and tmp folders

### DIFF
--- a/charts/rasa-x/Chart.yaml
+++ b/charts/rasa-x/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 
-version: "4.5.21"
+version: "4.5.22"
 
 appVersion: "1.2.2"
 

--- a/charts/rasa-x/nginx-config-files/nginx.conf
+++ b/charts/rasa-x/nginx-config-files/nginx.conf
@@ -1,7 +1,7 @@
 worker_processes  auto;
 worker_rlimit_nofile 10000;
 error_log /dev/stdout info;
-pid "/etc/nginx/nginx.pid";
+pid "{{ trimSuffix "/" .Values.nginx.runFolderPath }}/nginx.pid";
 
 events {
     worker_connections 4096;
@@ -18,11 +18,11 @@ http {
 
     access_log /dev/stdout;
 
-    client_body_temp_path  "/etc/nginx/client_body" 1 2;
-    proxy_temp_path        "/etc/nginx/proxy" 1 2;
-    fastcgi_temp_path      "/etc/nginx/fastcgi" 1 2;
-    scgi_temp_path         "/etc/nginx/scgi" 1 2;
-    uwsgi_temp_path        "/etc/nginx/uwsgi" 1 2;
+    client_body_temp_path  "{{ trimSuffix "/" .Values.nginx.tmpFolderPath }}/client_body" 1 2;
+    proxy_temp_path        "{{ trimSuffix "/" .Values.nginx.tmpFolderPath }}/proxy" 1 2;
+    fastcgi_temp_path      "{{ trimSuffix "/" .Values.nginx.tmpFolderPath }}/fastcgi" 1 2;
+    scgi_temp_path         "{{ trimSuffix "/" .Values.nginx.tmpFolderPath }}/scgi" 1 2;
+    uwsgi_temp_path        "{{ trimSuffix "/" .Values.nginx.tmpFolderPath }}/uwsgi" 1 2;
 
     sendfile        on;
 

--- a/charts/rasa-x/values.yaml
+++ b/charts/rasa-x/values.yaml
@@ -225,7 +225,7 @@ rasa:
     #       key: url
     # - name: "CUSTOM_MODEL_SERVER"
     #   value: "https://your-model-server/models/latest-model.tar.gz"
-  
+
   # tolerations can be used to control the pod to node assignment
   # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   tolerations: []
@@ -676,6 +676,14 @@ nginx:
   # podLabels adds additional pod labels
   # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   podLabels: {}
+
+  # runFolderPath specifies where the nginx.pid file will be written
+  # change the path from the default /etc/nginx in case that folder is not writeable
+  runFolderPath: /etc/nginx
+
+  # tmpFolderPath specifies the main path where client_body, proxy, fastcgi, scgi, and uwsgi subfolders are written
+  # change the path from the default /etc/nginx in case that folder is not writeable
+  tmpFolderPath: /etc/nginx
 
 # Duckling specific settings
 duckling:


### PR DESCRIPTION
**Scenario**
Deployment with
```yaml
nginx:
  enabled: true
```
and read only file systems enforced.

This may not be a classic or common scenario, as most of the time having only ingresses is enough, but it may still be possible and given that the chart supports it I think it's worth opening this PR.

**Problem**
```
    pid "/etc/nginx/nginx.pid";
```
 and 
```
    client_body_temp_path  "/etc/nginx/client_body" 1 2;
    proxy_temp_path        "/etc/nginx/proxy" 1 2;
    fastcgi_temp_path      "/etc/nginx/fastcgi" 1 2;
    scgi_temp_path         "/etc/nginx/scgi" 1 2;
    uwsgi_temp_path        "/etc/nginx/uwsgi" 1 2;
```
are all in the root of the nginx configuration folder.
While the temp path could be mounted one by one, making lots of noise in the chart configuration, the same workaround can't be applied to the `pid` configuration.

**Proposed solution**
Allow to configure the `pid` path and a temporary folder.
```yaml
  # runFolderPath specifies where the nginx.pid file will be written
  # change the path from the default /etc/nginx in case that folder is not writeable
  runFolderPath: /etc/nginx

  # tmpFolderPath specifies the main path where client_body, proxy, fastcgi, scgi, and uwsgi subfolders are written
  # change the path from the default /etc/nginx in case that folder is not writeable
  tmpFolderPath: /etc/nginx
```

By default the old paths are used in order to avoid breaking any existing deployment.

**Results**
With default values:
```
worker_processes  auto;
worker_rlimit_nofile 10000;
error_log /dev/stdout info;
pid "/etc/nginx/nginx.pid";

events {
    worker_connections 4096;
}


http {
    include       /etc/nginx/mime.types;
    default_type  application/octet-stream;

    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                      '$status $body_bytes_sent "$http_referer" '
                      '"$http_user_agent" "$http_x_forwarded_for"';

    access_log /dev/stdout;

    client_body_temp_path  "/etc/nginx/client_body" 1 2;
    proxy_temp_path        "/etc/nginx/proxy" 1 2;
    fastcgi_temp_path      "/etc/nginx/fastcgi" 1 2;
    scgi_temp_path         "/etc/nginx/scgi" 1 2;
    uwsgi_temp_path        "/etc/nginx/uwsgi" 1 2;

    sendfile        on;

    keepalive_timeout  65;

    gzip on;
    gzip_vary on;
    gzip_min_length 1400;
    gzip_proxied expired no-cache no-store private auth;
    gzip_types text/plain text/css text/xml text/javascript application/javascript application/json application/x-javascript application/xml;

    include /etc/nginx/conf.d/*.nginx;

    # allow the server to close connection on non responding client, this will free up memory
    reset_timedout_connection on;

    # request timed out -- default 60
    client_body_timeout 10;

    # if client stop responding, free up memory -- default 60
    send_timeout 2;

    # server will close connection after this time -- default 75
    proxy_read_timeout 3600;

    # number of requests client can make over keep-alive -- for testing environment
    keepalive_requests 100000;

    # whether the connection with a proxied server should be closed
    # when a client closes the connection without waiting for a response
    # default is off
    proxy_ignore_client_abort on;
    server_tokens off;

    # Disallow indexing
    add_header X-Robots-Tag none;
}
```
With user provided values:
```
worker_processes  auto;
worker_rlimit_nofile 10000;
error_log /dev/stdout info;
pid "/var/run/nginx/nginx.pid";

events {
    worker_connections 4096;
}


http {
    include       /etc/nginx/mime.types;
    default_type  application/octet-stream;

    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                      '$status $body_bytes_sent "$http_referer" '
                      '"$http_user_agent" "$http_x_forwarded_for"';

    access_log /dev/stdout;

    client_body_temp_path  "/tmp/nginx/client_body" 1 2;
    proxy_temp_path        "/tmp/nginx/proxy" 1 2;
    fastcgi_temp_path      "/tmp/nginx/fastcgi" 1 2;
    scgi_temp_path         "/tmp/nginx/scgi" 1 2;
    uwsgi_temp_path        "/tmp/nginx/uwsgi" 1 2;

    sendfile        on;

    keepalive_timeout  65;

    gzip on;
    gzip_vary on;
    gzip_min_length 1400;
    gzip_proxied expired no-cache no-store private auth;
    gzip_types text/plain text/css text/xml text/javascript application/javascript application/json application/x-javascript application/xml;

    include /etc/nginx/conf.d/*.nginx;

    # allow the server to close connection on non responding client, this will free up memory
    reset_timedout_connection on;

    # request timed out -- default 60
    client_body_timeout 10;

    # if client stop responding, free up memory -- default 60
    send_timeout 2;

    # server will close connection after this time -- default 75
    proxy_read_timeout 3600;

    # number of requests client can make over keep-alive -- for testing environment
    keepalive_requests 100000;

    # whether the connection with a proxied server should be closed
    # when a client closes the connection without waiting for a response
    # default is off
    proxy_ignore_client_abort on;
    server_tokens off;

    # Disallow indexing
    add_header X-Robots-Tag none;
}
```