### PR TITLE
Add extra path

### DIFF
--- a/charts/rasa-x/templates/ingress.yaml
+++ b/charts/rasa-x/templates/ingress.yaml
@@ -59,5 +59,23 @@ spec:
               servicePort: {{ $svcPort }}
         {{- end }}
   {{- end }}
+  {{- if .extraPaths }}
+    {{- range .extraPaths }}
+          - path: {{ .path }}
+      {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+      {{- end }}
+            backend:
+            {{- if semverCompare ">1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ .serviceName }}
+                port:
+                number: {{ .serviceName }}
+            {{- else }}
+              serviceName: {{ .serviceName }}
+              servicePort: {{ .servicePort }}
+            {{- end }}
+      {{- end }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/rasa-x/templates/ingress.yaml
+++ b/charts/rasa-x/templates/ingress.yaml
@@ -59,23 +59,5 @@ spec:
               servicePort: {{ $svcPort }}
         {{- end }}
   {{- end }}
-  {{- if .extraPaths }}
-    {{- range .extraPaths }}
-          - path: {{ .path }}
-      {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
-      {{- end }}
-            backend:
-            {{- if semverCompare ">1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-              service:
-                name: {{ .serviceName }}
-                port:
-                number: {{ .serviceName }}
-            {{- else }}
-              serviceName: {{ .serviceName }}
-              servicePort: {{ .servicePort }}
-            {{- end }}
-      {{- end }}
-  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/rasa-x/templates/rasa-open-source-api-ingress.yaml
+++ b/charts/rasa-x/templates/rasa-open-source-api-ingress.yaml
@@ -57,6 +57,17 @@ spec:
         path: /core
         {{ end -}}
         pathType: Prefix
+      {{- if .extraPaths }}
+      {{- range .extraPaths }}
+      - backend:
+          service:
+            name: {{ .serviceName }}
+            port:
+              number: {{ .servicePort }}
+        path: {{ .path }}
+        pathType: {{ .pathType }}
+        {{- end }}
+      {{- end }}
     {{- end }}
 {{- else -}}
     {{- range .Values.ingress.hosts }}
@@ -71,6 +82,14 @@ spec:
         {{ else -}}
         path: /core
         {{ end -}}
+    {{- if .extraPaths }}
+      {{- range .extraPaths }}
+      - backend:
+          serviceName: {{ .serviceName }}
+          servicePort: {{ .servicePort }}
+        path: {{ .path }}
+      {{- end }}
+    {{- end }}
     {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
request the ability to add additional paths to the ingress of the `rasa` open source ingress so expose `/api` endpoint of rasa. 
I borrowed the idea from `rasa-pro` charts to add the additional Paths in `open-source ingress`. 

Let me know if this is okay. 